### PR TITLE
mip load: automatically load package dependencies

### DIFF
--- a/src/cli-repl.ts
+++ b/src/cli-repl.ts
@@ -76,14 +76,16 @@ export async function runRepl(
     for (const d of directives) {
       if (d.type === "load") {
         console.log(`Loading mip package: ${d.packageName}...`);
-        const paths = processMipLoad(d.packageName);
-        for (const p of paths) {
-          searchPaths.push(p);
-          workspaceFiles.push(...scanMFiles(p));
+        const results = processMipLoad(d.packageName);
+        for (const result of results) {
+          for (const p of result.paths) {
+            searchPaths.push(p);
+            workspaceFiles.push(...scanMFiles(p));
+          }
+          console.log(
+            `  Loaded ${result.packageName} (${result.paths.length} path(s) added)`
+          );
         }
-        console.log(
-          `  Loaded ${d.packageName} (${paths.length} path(s) added)`
-        );
       }
     }
     const trimmedClean = cleanedSource.trim();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -391,7 +391,9 @@ async function cmdRun(args: string[]) {
   const mipPaths: string[] = [];
   for (const d of directives) {
     if (d.type === "load") {
-      mipPaths.push(...processMipLoad(d.packageName));
+      for (const result of processMipLoad(d.packageName)) {
+        mipPaths.push(...result.paths);
+      }
     }
   }
 

--- a/src/mip-directives.ts
+++ b/src/mip-directives.ts
@@ -17,10 +17,15 @@ export {
   type MipDirectiveResult,
 } from "./mip-directives-core.js";
 
+export interface MipLoadResult {
+  packageName: string;
+  paths: string[];
+}
+
 export function processMipLoad(
   packageName: string,
   _visited?: Set<string>
-): string[] {
+): MipLoadResult[] {
   const visited = _visited ?? new Set<string>();
   if (visited.has(packageName)) return [];
   visited.add(packageName);
@@ -36,7 +41,7 @@ export function processMipLoad(
   }
 
   // Load dependencies first by reading mip.json
-  const allPaths: string[] = [];
+  const allResults: MipLoadResult[] = [];
   const mipJsonPath = join(pkgDir, "mip.json");
   if (existsSync(mipJsonPath)) {
     try {
@@ -50,7 +55,7 @@ export function processMipLoad(
           );
           continue;
         }
-        allPaths.push(...processMipLoad(dep, visited));
+        allResults.push(...processMipLoad(dep, visited));
       }
     } catch {
       // If mip.json is malformed, continue without dependencies
@@ -100,6 +105,6 @@ export function processMipLoad(
   executeCode(source, { customBuiltins }, [], loadScript);
 
   // Dependencies first, then this package's paths
-  allPaths.push(...collectedPaths);
-  return allPaths;
+  allResults.push({ packageName, paths: collectedPaths });
+  return allResults;
 }


### PR DESCRIPTION
## Summary
- When `mip load <package>` is called, the package's `mip.json` is now read to discover dependencies
- Dependencies are recursively loaded (dependencies-first order) before the requested package
- Circular dependencies are handled via a visited set
- Missing dependencies produce a warning and are skipped gracefully

Closes #1

## Test plan
- [ ] Verify `mip load` on a package with no dependencies still works as before
- [ ] Install a package with dependencies (e.g., one that depends on another) and verify `mip load` loads both
- [ ] Verify circular dependency chains don't cause infinite loops
- [ ] Verify a warning is printed when a dependency is not installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)