### PR TITLE
Expand exist() compile-time resolution for all searchTypes

### DIFF
--- a/numbl_test_scripts/variables/test_exist_builtin.m
+++ b/numbl_test_scripts/variables/test_exist_builtin.m
@@ -1,0 +1,17 @@
+% Test exist() with 'builtin' option
+
+% Known built-in functions should return 5
+assert(exist('sin', 'builtin') == 5, 'sin is a builtin');
+assert(exist('cos', 'builtin') == 5, 'cos is a builtin');
+assert(exist('zeros', 'builtin') == 5, 'zeros is a builtin');
+assert(exist('disp', 'builtin') == 5, 'disp is a builtin');
+assert(exist('numel', 'builtin') == 5, 'numel is a builtin');
+assert(exist('size', 'builtin') == 5, 'size is a builtin');
+assert(exist('length', 'builtin') == 5, 'length is a builtin');
+assert(exist('isempty', 'builtin') == 5, 'isempty is a builtin');
+
+% Non-existent names should return 0
+assert(exist('nonexistent_xyz_abc', 'builtin') == 0, 'nonexistent is not a builtin');
+assert(exist('my_user_func_xyz', 'builtin') == 0, 'user func is not a builtin');
+
+disp('SUCCESS');

--- a/numbl_test_scripts/variables/test_exist_class/MyExistClass.m
+++ b/numbl_test_scripts/variables/test_exist_class/MyExistClass.m
@@ -1,0 +1,12 @@
+classdef MyExistClass
+    properties
+        value
+    end
+    methods
+        function obj = MyExistClass(v)
+            if nargin > 0
+                obj.value = v;
+            end
+        end
+    end
+end

--- a/numbl_test_scripts/variables/test_exist_class/test_exist_class.m
+++ b/numbl_test_scripts/variables/test_exist_class/test_exist_class.m
@@ -1,0 +1,12 @@
+% Test exist() with 'class' option
+
+% Workspace class should return 8
+assert(exist('MyExistClass', 'class') == 8, 'workspace class should return 8');
+
+% Non-existent class should return 0
+assert(exist('nonexistent_class_xyz', 'class') == 0, 'nonexistent class should return 0');
+
+% Built-in functions are not classes
+assert(exist('sin', 'class') == 0, 'builtin function is not a class');
+
+disp('SUCCESS');

--- a/numbl_test_scripts/variables/test_exist_dir.m
+++ b/numbl_test_scripts/variables/test_exist_dir.m
@@ -1,0 +1,13 @@
+% Test exist() with 'dir' option
+
+% Non-existent folder should return 0
+assert(exist('nonexistent_folder_xyz', 'dir') == 0, 'nonexistent folder should return 0');
+
+% A builtin function is not a folder
+assert(exist('sin', 'dir') == 0, 'builtin is not a folder');
+
+% A workspace variable is not a folder
+my_var = 42;
+assert(exist('my_var', 'dir') == 0, 'variable is not a folder');
+
+disp('SUCCESS');

--- a/numbl_test_scripts/variables/test_exist_file/my_workspace_helper.m
+++ b/numbl_test_scripts/variables/test_exist_file/my_workspace_helper.m
@@ -1,0 +1,3 @@
+function result = my_workspace_helper(x)
+  result = x * 2;
+end

--- a/numbl_test_scripts/variables/test_exist_file/test_exist_file.m
+++ b/numbl_test_scripts/variables/test_exist_file/test_exist_file.m
@@ -1,0 +1,13 @@
+% Test exist() with 'file' option
+% my_workspace_helper.m is a workspace function in the same directory
+
+% Workspace function file should return 2
+assert(exist('my_workspace_helper', 'file') == 2, 'workspace function should return 2 for file');
+
+% Non-existent file should return 0
+assert(exist('nonexistent_file_xyz', 'file') == 0, 'nonexistent file should return 0');
+
+% Built-in is not a file
+assert(exist('sin', 'file') == 0, 'builtin is not a file');
+
+disp('SUCCESS');

--- a/numbl_test_scripts/variables/test_exist_single.m
+++ b/numbl_test_scripts/variables/test_exist_single.m
@@ -1,0 +1,22 @@
+% Test exist() with a single argument
+
+% Variable in workspace -> 1
+myvar = 42;
+assert(exist('myvar') == 1, 'defined variable should return 1');
+
+% Variable that does not exist -> 0
+assert(exist('undefined_var_xyz') == 0, 'undefined variable should return 0');
+
+% Built-in function -> 5 (when no variable shadows it)
+assert(exist('sin') == 5, 'sin should return 5 (builtin)');
+assert(exist('cos') == 5, 'cos should return 5 (builtin)');
+assert(exist('zeros') == 5, 'zeros should return 5 (builtin)');
+
+% Variable shadows builtin: if a var named 'zeros' is defined, return 1
+zeros_var = 99;
+assert(exist('zeros_var') == 1, 'defined variable should return 1');
+
+% Completely unknown name -> 0
+assert(exist('totally_nonexistent_abc123') == 0, 'unknown name should return 0');
+
+disp('SUCCESS');

--- a/src/numbl-core/codegen/codegenExpr.ts
+++ b/src/numbl-core/codegen/codegenExpr.ts
@@ -23,6 +23,7 @@ import {
 
 import type { CallSite } from "../runtime/runtimeHelpers.js";
 import { resolveFunction } from "../functionResolve.js";
+import { isBuiltin } from "../builtins/index.js";
 
 // ── Public entry ────────────────────────────────────────────────────────
 
@@ -722,18 +723,51 @@ function genFuncCall(
     return `$rt.makeString('"${typeStr}"')`;
   }
   if (kind.name === "isa") return `$rt.isa(${args[0]}, ${args[1]})`;
-  if (kind.name === "exist" && kind.args.length === 2) {
-    const arg0 = kind.args[0].kind;
-    const arg1 = kind.args[1].kind;
-    if (arg0.type === "Char" && arg1.type === "Char") {
-      const varName = arg0.value.replace(/^'|'$/g, "");
-      const typeArg = arg1.value.replace(/^'|'$/g, "");
-      if (typeArg === "var") {
-        const variable = cg.loweringCtx.allVariables.find(
-          v => v.name === varName
-        );
+  if (kind.name === "exist") {
+    const fnIndex = cg.loweringCtx.functionIndex;
+    if (kind.args.length === 2) {
+      const arg0 = kind.args[0].kind;
+      const arg1 = kind.args[1].kind;
+      if (arg0.type === "Char" && arg1.type === "Char") {
+        const name = arg0.value.replace(/^'|'$/g, "");
+        const typeArg = arg1.value.replace(/^'|'$/g, "");
+        if (typeArg === "var") {
+          const variable = cg.loweringCtx.allVariables.find(
+            v => v.name === name
+          );
+          if (variable) {
+            return `(${cg.varRef(variable.id.id)} !== undefined ? 1 : 0)`;
+          }
+          return "0";
+        }
+        if (typeArg === "builtin") {
+          return isBuiltin(name) ? "5" : "0";
+        }
+        if (typeArg === "file") {
+          return fnIndex.workspaceFunctions.has(name) ? "2" : "0";
+        }
+        if (typeArg === "class") {
+          return fnIndex.workspaceClasses.has(name) ? "8" : "0";
+        }
+        if (typeArg === "dir") {
+          return "0";
+        }
+      }
+    }
+    if (kind.args.length === 1) {
+      const arg0 = kind.args[0].kind;
+      if (arg0.type === "Char") {
+        const name = arg0.value.replace(/^'|'$/g, "");
+        // Priority: variable → builtin → workspace function → 0
+        const variable = cg.loweringCtx.allVariables.find(v => v.name === name);
         if (variable) {
           return `(${cg.varRef(variable.id.id)} !== undefined ? 1 : 0)`;
+        }
+        if (isBuiltin(name)) {
+          return "5";
+        }
+        if (fnIndex.workspaceFunctions.has(name)) {
+          return "2";
         }
         return "0";
       }


### PR DESCRIPTION
Closes #11

## Summary

- Extends the codegen special case for `exist()` with literal string arguments to cover all `searchType` values and the single-argument form
- Adds test scripts for each variant

| Form | Returns |
|---|---|
| `exist('x', 'var')` | `1` if variable in scope, else `0` (existing) |
| `exist('f', 'builtin')` | `5` if registered builtin, else `0` |
| `exist('f', 'file')` | `2` if workspace function, else `0` |
| `exist('C', 'class')` | `8` if workspace class, else `0` |
| `exist('x', 'dir')` | always `0` (no filesystem access) |
| `exist('x')` | `1` (var) → `5` (builtin) → `2` (workspace fn) → `0` |

All resolution happens at compile time via the existing lowering context (`allVariables`, `functionIndex.workspaceFunctions`, `functionIndex.workspaceClasses`) and the builtin registry (`isBuiltin`). The runtime fallback in `misc.ts` is unchanged and still handles dynamic (non-literal) argument cases.

## Test plan

- `test_exist_var.m` — `'var'` searchType (pre-existing, still passes)
- `test_exist_builtin.m` — `'builtin'` searchType
- `test_exist_file/` — `'file'` searchType with companion workspace function
- `test_exist_class/` — `'class'` searchType with companion classdef
- `test_exist_dir.m` — `'dir'` searchType
- `test_exist_single.m` — single-argument form