### PR TITLE
C-JIT: fused per-element loops (--fuse)

### DIFF
--- a/benchmarks/tensor_ops_bench.md
+++ b/benchmarks/tensor_ops_bench.md
@@ -18,12 +18,13 @@ loop-JIT can specialize the full iteration as a single C function under
 ## How to run
 
 ```bash
-npx tsx src/cli.ts run benchmarks/tensor_ops_bench.m --opt 0   # interpreter
-npx tsx src/cli.ts run benchmarks/tensor_ops_bench.m --opt 1   # JS-JIT
-npx tsx src/cli.ts run benchmarks/tensor_ops_bench.m --opt 2   # C-JIT
+npx tsx src/cli.ts run benchmarks/tensor_ops_bench.m --opt 0          # interpreter
+npx tsx src/cli.ts run benchmarks/tensor_ops_bench.m --opt 1          # JS-JIT
+npx tsx src/cli.ts run benchmarks/tensor_ops_bench.m --opt 2          # C-JIT (per-op)
+npx tsx src/cli.ts run benchmarks/tensor_ops_bench.m --opt 2 --fuse   # C-JIT (fused)
 matlab -batch "run('benchmarks/tensor_ops_bench.m')"
 (cd benchmarks && octave --no-gui --quiet --eval tensor_ops_bench)
-bash benchmarks/tensor_ops_bench_compare.sh                    # all of the above
+bash benchmarks/tensor_ops_bench_compare.sh                           # all of the above
 ```
 
 All runs produce the same check values (to FP rounding).
@@ -35,52 +36,59 @@ All runs produce the same check values (to FP rounding).
 - **Toolchain:** Node v24.14.1, cc 14.2.0, numbl 0.1.7
 - **MATLAB:** R2025b Update 5 · **Octave:** 9.4.0
 
-Median of 3 runs per numbl mode; single run for MATLAB/Octave.
+Median of 3 runs for all modes.
 
-| Mode                    |  Total | Binary |  Unary | Cmp+Red | Reduce |  Chain |
-| ----------------------- | -----: | -----: | -----: | ------: | -----: | -----: |
-| `--opt 0` (interpreter) | 6.10 s | 1.10 s | 2.99 s |  0.54 s | 0.33 s | 1.13 s |
-| `--opt 1` (JS-JIT)      | 3.49 s | 0.71 s | 1.48 s |  0.36 s | 0.32 s | 0.63 s |
-| `--opt 2` (C-JIT)       | 3.35 s | 0.72 s | 1.46 s |  0.32 s | 0.27 s | 0.60 s |
-| MATLAB R2025b `-batch`  | 3.19 s | 0.28 s | 2.10 s |  0.20 s | 0.20 s | 0.42 s |
-| Octave 9.4 `--eval`     | 8.77 s | 1.03 s | 4.87 s |  0.88 s | 0.37 s | 1.62 s |
-| C baseline, per-op      | 2.63 s | 0.58 s | 1.22 s |  0.24 s | 0.11 s | 0.49 s |
-| C baseline, fused       | 1.03 s | 0.10 s | 0.68 s |  0.07 s | 0.04 s | 0.13 s |
+| Mode                     |  Total | Binary |  Unary | Cmp+Red | Reduce |  Chain |
+| ------------------------ | -----: | -----: | -----: | ------: | -----: | -----: |
+| `--opt 0` (interpreter)  | 5.29 s | 1.25 s | 2.42 s |  0.52 s | 0.27 s | 0.96 s |
+| `--opt 1` (JS-JIT)       | 3.27 s | 0.66 s | 1.36 s |  0.34 s | 0.30 s | 0.61 s |
+| `--opt 2` (C-JIT)        | 3.09 s | 0.66 s | 1.34 s |  0.30 s | 0.25 s | 0.55 s |
+| `--opt 2 --fuse` (C-JIT) | 1.56 s | 0.10 s | 0.57 s |  0.28 s | 0.24 s | 0.38 s |
+| MATLAB R2025b `-batch`   | 2.86 s | 0.29 s | 1.82 s |  0.17 s | 0.18 s | 0.37 s |
+| Octave 9.4 `--eval`      | 7.75 s | 0.98 s | 4.41 s |  0.75 s | 0.30 s | 1.40 s |
+| C baseline, per-op       | 2.63 s | 0.58 s | 1.22 s |  0.24 s | 0.11 s | 0.49 s |
+| C baseline, fused        | 1.03 s | 0.10 s | 0.68 s |  0.07 s | 0.04 s | 0.13 s |
 
 ### macOS — TBD
 
-| Mode                    | Total | Binary | Unary | Cmp+Red | Reduce | Chain |
-| ----------------------- | ----: | -----: | ----: | ------: | -----: | ----: |
-| `--opt 0` (interpreter) |       |        |       |         |        |       |
-| `--opt 1` (JS-JIT)      |       |        |       |         |        |       |
-| `--opt 2` (C-JIT)       |       |        |       |         |        |       |
-| MATLAB `-batch`         |       |        |       |         |        |       |
-| Octave `--eval`         |       |        |       |         |        |       |
+| Mode                     | Total | Binary | Unary | Cmp+Red | Reduce | Chain |
+| ------------------------ | ----: | -----: | ----: | ------: | -----: | ----: |
+| `--opt 0` (interpreter)  |       |        |       |         |        |       |
+| `--opt 1` (JS-JIT)       |       |        |       |         |        |       |
+| `--opt 2` (C-JIT)        |       |        |       |         |        |       |
+| `--opt 2 --fuse` (C-JIT) |       |        |       |         |        |       |
+| MATLAB `-batch`          |       |        |       |         |        |       |
+| Octave `--eval`          |       |        |       |         |        |       |
 
 ## Reading the table
 
-- **`--opt 2` (C-JIT) is ~4% faster overall than `--opt 1` (JS-JIT).**
-  The C-JIT compiles each loop body to a single `.so` loaded via koffi,
-  with direct `numbl_real_*` calls and lazy-allocated scratch buffers
-  reused across iterations. The main wins are on reductions (−16%) and
-  comparisons (−11%), where eliminating per-statement JS overhead matters
-  most.
-- **MATLAB is ~5% faster overall** than `--opt 2`, but slower on unary
-  ops (2.10 s vs 1.46 s). MATLAB's binary dispatch and BLAS-backed
-  element-wise ops are highly optimized; numbl's `libnumbl_ops` kernels
-  are competitive on transcendentals (exp/sin/cos/tanh).
-- **The C baselines bracket future optimization headroom.** `per-op`
-  (2.63 s) is the ceiling for the current per-statement architecture —
-  any mode that calls libnumbl_ops per op can approach but not beat it.
-  `fused` (1.03 s) is the ceiling if the C-JIT ever emits fused per-
-  element loops instead of chained libnumbl_ops calls.
-- **Octave** is ~2.5× slower than numbl's C-JIT. Octave's experimental
-  JIT is off by default in 9.x.
-- **No exit hangs.** The koffi-based `.so` loading has no Node module
-  registration or libuv teardown hooks, eliminating the process-exit
-  hangs that affected the previous N-API `.node` approach.
+- **`--opt 2 --fuse` is 1.8× faster than MATLAB overall** and 2× faster
+  than per-op C-JIT. The fused codegen collapses consecutive tensor
+  element-wise assigns into a single `for` loop with inline scalar
+  expressions per element — no libnumbl_ops calls, no intermediate
+  buffers, one memory pass. The compiler auto-vectorizes via
+  `#pragma omp simd` and `-fopenmp-simd -ffast-math`.
+- **Binary fusion matches the hand-written C baseline** (0.10 s vs
+  0.10 s). All four ops run in a single SIMD-vectorized loop with one
+  read of `x[i]`/`y[i]` and one write of `r[i]`.
+- **Unary fusion beats the C baseline** (0.57 s vs 0.68 s). The fused
+  loop keeps all transcendentals (`exp`, `cos`, `sin`, `tanh`) in
+  registers; the baseline was compiled separately and may not benefit
+  from the same cross-function inlining.
+- **MATLAB is faster on reductions and comparisons** (0.17 s vs 0.28 s).
+  The comparison kernel's `sum(c1 .* c2)` pattern is not yet fused into
+  the comparison chain — `c1` and `c2` are fused, but the subsequent
+  `sum(c1.*c2)` falls back to per-op. Fusing reduction of arbitrary
+  tensor expressions (not just the last chain variable) is future work.
+- **Per-op C-JIT (`--opt 2`) is ~5% faster than JS-JIT** on the same
+  per-statement architecture. The C-JIT eliminates per-statement JS
+  overhead; the main wins are on reductions and comparisons.
+- **Octave** is ~5× slower than numbl's fused C-JIT. Octave's
+  experimental JIT is off by default in 9.x.
 
-## C-JIT architecture (koffi)
+## C-JIT architecture
+
+### Per-op mode (`--opt 2`)
 
 The C-JIT emits pure C functions with raw `double*` / `int64_t`
 parameters — no N-API, no `napi_value`, no `napi_env`. Each compiled
@@ -90,29 +98,49 @@ loop body is a self-contained `.so` loaded via [koffi](https://koffi.dev)
 Generated C for the binary kernel (simplified):
 
 ```c
-void jit__loop_for(
-    double v_trials,
-    const double *v_x_data, int64_t v_x_len,
-    const double *v_y_data, int64_t v_y_len,
-    const double *v_r_data_in, int64_t v_r_len_in,
-    double *v_k_out,
-    double *v_r_buf, int64_t *v_r_out_len)
-{
-  double *v_r_data = v_r_buf;
-  int64_t v_r_len = v_r_len_in;
-  double *__s1_data = NULL; /* scratch, lazily allocated */
-  ...
-  for (double __t1 = 1.0; __t1 <= v_trials; __t1 += 1.0) {
-    v_r_len = v_x_len;
-    numbl_real_binary_elemwise(NUMBL_REAL_BIN_ADD, v_r_len, v_x_data, v_y_data, v_r_data);
-    if (!__s1_data) __s1_data = malloc(v_r_len * sizeof(double));
-    numbl_real_scalar_binary_elemwise(NUMBL_REAL_BIN_MUL, v_r_len, 0.5, v_x_data, 1, __s1_data);
-    numbl_real_binary_elemwise(NUMBL_REAL_BIN_SUB, v_r_len, v_r_data, __s1_data, v_r_data);
+for (double __t1 = 1.0; __t1 <= v_trials; __t1 += 1.0) {
+    numbl_real_binary_elemwise(ADD, v_x_len, v_x_data, v_y_data, v_r_data);
+    if (!__s1_data) __s1_data = malloc(v_x_len * sizeof(double));
+    numbl_real_scalar_binary_elemwise(MUL, v_x_len, 0.5, v_x_data, 1, __s1_data);
+    numbl_real_binary_elemwise(SUB, v_x_len, v_r_data, __s1_data, v_r_data);
     ...
-  }
-  *v_k_out = v_k;
-  *v_r_out_len = v_r_len;
-  free(__s1_data); ...
+}
+```
+
+### Fused mode (`--opt 2 --fuse`)
+
+The fusion pass (`cFusion.ts`) scans the loop body for runs of
+consecutive tensor element-wise assigns and collapses them into a single
+per-element `for` loop (`cFusedCodegen.ts`). Trailing reductions
+(`acc += sum(r)`) are absorbed as inline accumulators.
+
+Generated C for the binary kernel:
+
+```c
+for (double __t1 = 1.0; __t1 <= v_trials; __t1 += 1.0) {
+    #pragma omp simd
+    for (int64_t __i = 0; __i < v_x_len; __i++) {
+      double __f_r = (v_x_data[__i] + v_y_data[__i]);
+      __f_r = (__f_r - (0.5 * v_x_data[__i]));
+      __f_r = ((__f_r * v_y_data[__i]) + 3.0);
+      __f_r = (__f_r / (1.0 + fabs(v_y_data[__i])));
+      v_r_data[__i] = __f_r;
+    }
+}
+```
+
+Generated C for the chain kernel (with fused reduction):
+
+```c
+for (double __t1 = 1.0; __t1 <= v_trials; __t1 += 1.0) {
+    double __f_reduce_acc = 0.0;
+    for (int64_t __i = 0; __i < v_x_len; __i++) {
+      double __f_r2 = ((v_x_data[__i] * v_y_data[__i]) + 0.5);
+      __f_r2 = exp((-__f_r2 * __f_r2));
+      __f_r2 = (__f_r2 * v_x_data[__i]);
+      __f_reduce_acc += __f_r2;
+    }
+    v_chain_acc += __f_reduce_acc;
 }
 ```
 
@@ -123,5 +151,8 @@ void jit__loop_for(
   to complex, libnumbl_ops returns NaN. Same behavior as JS-JIT.
 - **Complex tensors** are not in the C-JIT path yet. Real-only.
 - **Compiled `.so` cache** lives at `~/.cache/numbl/c-jit/<sha>.so`,
-  keyed by source + compiler/platform/numbl versions + `libnumbl_ops.a`
-  contents.
+  keyed by source + compiler/platform/numbl versions + git HEAD +
+  `libnumbl_ops.a` contents.
+- **`-ffast-math`** is enabled for the C-JIT compile. This allows SIMD
+  vectorization of transcendentals but changes FP rounding — check
+  values may differ slightly between modes.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -324,6 +324,7 @@ Options (for run and eval):
                            via cc, load as a .node module, fall back to JS-JIT
                            on infeasible IR (requires a C compiler and Node API
                            headers; prints its compile command once to stderr)
+  --fuse             Emit fused per-element loops in C-JIT (requires --opt 2)
 
 Environment variables:
   NUMBL_PATH              Extra workspace directories (separated by ${delimiter})
@@ -347,6 +348,7 @@ interface ParsedOptions {
   positional: string[];
   profileOutput: string | undefined;
   optimization: number;
+  fuse: boolean;
 }
 
 function parseOptions(args: string[]): ParsedOptions {
@@ -362,6 +364,7 @@ function parseOptions(args: string[]): ParsedOptions {
     positional: [],
     profileOutput: undefined,
     optimization: 1,
+    fuse: false,
   };
 
   // Seed extraPaths from NUMBL_PATH environment variable (platform path separator)
@@ -449,6 +452,9 @@ function parseOptions(args: string[]): ParsedOptions {
           console.error("Error: --opt requires a valid number");
           process.exit(1);
         }
+        break;
+      case "--fuse":
+        opts.fuse = true;
         break;
       default:
         if (args[i].startsWith("-")) {
@@ -658,6 +664,7 @@ async function executeWithOptions(
             onInput,
 
             optimization: opts.optimization,
+            fuse: opts.fuse,
           },
           workspaceFiles,
           mainFileName,
@@ -714,6 +721,7 @@ async function executeWithOptions(
           system,
           onInput,
           optimization: opts.optimization,
+          fuse: opts.fuse,
         },
         workspaceFiles,
         mainFileName,
@@ -753,6 +761,7 @@ async function executeWithOptions(
           system,
           onInput,
           optimization: opts.optimization,
+          fuse: opts.fuse,
         },
         workspaceFiles,
         mainFileName,

--- a/src/numbl-core/executeCode.ts
+++ b/src/numbl-core/executeCode.ts
@@ -65,6 +65,8 @@ export interface ExecOptions {
   onInput?: (prompt: string) => string;
   /** Optimization level for interpreter (0 = none, >=1 = JIT scalar functions). */
   optimization?: number;
+  /** Emit fused per-element loops in C-JIT (requires --opt 2). */
+  fuse?: boolean;
   /**
    * Initial implicit cwd path for the MATLAB-style "cwd is the first search path" feature.
    * - undefined → auto-detect from `system.cwd()` and scan its files.
@@ -351,6 +353,7 @@ export function executeCode(
   }
 
   interpreter.optimization = options.optimization ?? 1;
+  interpreter.fuse = options.fuse ?? false;
   interpreter.log = options.log;
 
   // Collect JIT compilations for generatedJS output and profiling

--- a/src/numbl-core/interpreter/interpreter.ts
+++ b/src/numbl-core/interpreter/interpreter.ts
@@ -105,6 +105,9 @@ export class Interpreter {
    */
   optimization: number = 1;
 
+  /** Emit fused per-element loops in C-JIT (--fuse flag). */
+  fuse: boolean = false;
+
   /** Callback for JIT compilation logging (JS codegen). */
   onJitCompile?: (description: string, jsCode: string) => void;
 

--- a/src/numbl-core/interpreter/jit/c/cCompile.ts
+++ b/src/numbl-core/interpreter/jit/c/cCompile.ts
@@ -159,7 +159,12 @@ function getCEnv(log?: (m: string) => void): CEnv | null {
 
   const skipNativeDefaults = !!process.env.NUMBL_NO_NATIVE_CFLAGS;
   if (!skipNativeDefaults) {
-    for (const flag of ["-march=native"]) {
+    for (const flag of [
+      "-march=native",
+      "-fopenmp-simd",
+      "-fno-math-errno",
+      "-ffast-math",
+    ]) {
       if (compilerAcceptsFlag(cc, flag)) flags.push(flag);
     }
   }

--- a/src/numbl-core/interpreter/jit/c/cFusedCodegen.ts
+++ b/src/numbl-core/interpreter/jit/c/cFusedCodegen.ts
@@ -1,0 +1,495 @@
+/**
+ * Fused per-element loop emission for the C-JIT.
+ *
+ * Given a FusibleChain (from cFusion.ts), emits a single
+ *   `for (int64_t __i = 0; __i < N; __i++) { ... }`
+ * loop that evaluates all the chain's tensor assigns as inline scalar
+ * expressions per element — no libnumbl_ops calls, no intermediate
+ * buffers.
+ *
+ * Scalar expressions (number literals, scalar vars, scalar math calls)
+ * pass through unchanged. Tensor var references become either:
+ *   - `v_name_data[__i]`  for input params / pre-existing tensors
+ *   - `__f_name`           for chain-produced intermediates (scalar local)
+ *
+ * The optional trailing reduction is absorbed as an inline accumulator
+ * (`__f_acc += expr`) inside the same loop, eliminating the need to
+ * materialise the tensor result at all when it is only consumed by the
+ * reduction.
+ */
+
+import { BinaryOperation, UnaryOperation } from "../../../parser/types.js";
+import type { JitExpr } from "../jitTypes.js";
+import type { FusibleChain } from "./cFusion.js";
+import { C_TENSOR_UNARY_OPS } from "./cFeasibility.js";
+
+const MANGLE_PREFIX = "v_";
+
+function mangle(name: string): string {
+  return `${MANGLE_PREFIX}${name}`;
+}
+
+function tensorData(name: string): string {
+  return `${mangle(name)}_data`;
+}
+
+function tensorLen(name: string): string {
+  return `${mangle(name)}_len`;
+}
+
+/** Format a number literal for C source. */
+function fmtNum(v: number): string {
+  if (!Number.isFinite(v)) {
+    if (Number.isNaN(v)) return "(0.0/0.0)";
+    return v > 0 ? "(1.0/0.0)" : "(-1.0/0.0)";
+  }
+  if (Number.isInteger(v)) return `${v}.0`;
+  return `${v}`;
+}
+
+/** Scalar C name for a chain-produced tensor intermediate. */
+function fusedLocal(name: string): string {
+  return `__f_${name}`;
+}
+
+// ── Scalar math builtins (mirrors jitCodegenC.ts) ────────────────────
+
+const BUILTIN_TO_C: Record<string, string> = {
+  sin: "sin",
+  cos: "cos",
+  tan: "tan",
+  asin: "asin",
+  acos: "acos",
+  atan: "atan",
+  sinh: "sinh",
+  cosh: "cosh",
+  tanh: "tanh",
+  asinh: "asinh",
+  acosh: "acosh",
+  atanh: "atanh",
+  exp: "exp",
+  log: "log",
+  log2: "log2",
+  log10: "log10",
+  sqrt: "sqrt",
+  abs: "fabs",
+  floor: "floor",
+  ceil: "ceil",
+  fix: "trunc",
+  round: "round",
+  atan2: "atan2",
+  hypot: "hypot",
+  rem: "fmod",
+  expm1: "expm1",
+  log1p: "log1p",
+  pow: "pow",
+  mod: "__numbl_mod",
+  sign: "__numbl_sign",
+};
+
+// ── Expression emission (per-element scalar form) ────────────────────
+
+/**
+ * Emit a JitExpr as a C scalar expression for element `__i`.
+ *
+ * `chainLocals` is the set of tensor variable names that have already
+ * been assigned within the current fused chain — these are read via
+ * the scalar local `__f_name` rather than `v_name_data[__i]`.
+ *
+ * `allTensorVars` is the full set of tensor-typed variables so we can
+ * distinguish tensor reads from scalar reads.
+ *
+ * `helpersNeeded` collects names of scalar helpers that need to be
+ * emitted (e.g. __numbl_mod).
+ */
+function emitScalarExpr(
+  expr: JitExpr,
+  chainLocals: ReadonlySet<string>,
+  allTensorVars: ReadonlySet<string>,
+  helpersNeeded: Set<string>
+): string {
+  switch (expr.tag) {
+    case "NumberLiteral":
+      return fmtNum(expr.value);
+
+    case "Var": {
+      if (expr.jitType.kind === "tensor" || allTensorVars.has(expr.name)) {
+        // Chain-produced intermediate → scalar local
+        if (chainLocals.has(expr.name)) return fusedLocal(expr.name);
+        // Input param / pre-existing tensor → array read
+        return `${tensorData(expr.name)}[__i]`;
+      }
+      return mangle(expr.name);
+    }
+
+    case "Binary":
+      return emitBinaryScalar(expr, chainLocals, allTensorVars, helpersNeeded);
+
+    case "Unary":
+      return emitUnaryScalar(expr, chainLocals, allTensorVars, helpersNeeded);
+
+    case "Call":
+      return emitCallScalar(expr, chainLocals, allTensorVars, helpersNeeded);
+
+    default:
+      throw new Error(
+        `cFusedCodegen: unsupported expr in fused chain: ${expr.tag}`
+      );
+  }
+}
+
+function emitBinaryScalar(
+  expr: JitExpr & { tag: "Binary" },
+  chainLocals: ReadonlySet<string>,
+  allTensorVars: ReadonlySet<string>,
+  helpersNeeded: Set<string>
+): string {
+  const l = emitScalarExpr(
+    expr.left,
+    chainLocals,
+    allTensorVars,
+    helpersNeeded
+  );
+  const r = emitScalarExpr(
+    expr.right,
+    chainLocals,
+    allTensorVars,
+    helpersNeeded
+  );
+
+  switch (expr.op) {
+    case BinaryOperation.Add:
+      return `(${l} + ${r})`;
+    case BinaryOperation.Sub:
+      return `(${l} - ${r})`;
+    case BinaryOperation.Mul:
+    case BinaryOperation.ElemMul:
+      return `(${l} * ${r})`;
+    case BinaryOperation.Div:
+    case BinaryOperation.ElemDiv:
+      return `(${l} / ${r})`;
+    case BinaryOperation.Pow:
+    case BinaryOperation.ElemPow:
+      return `pow(${l}, ${r})`;
+    case BinaryOperation.Equal:
+      return `((double)((${l}) == (${r})))`;
+    case BinaryOperation.NotEqual:
+      return `((double)((${l}) != (${r})))`;
+    case BinaryOperation.Less:
+      return `((double)((${l}) < (${r})))`;
+    case BinaryOperation.LessEqual:
+      return `((double)((${l}) <= (${r})))`;
+    case BinaryOperation.Greater:
+      return `((double)((${l}) > (${r})))`;
+    case BinaryOperation.GreaterEqual:
+      return `((double)((${l}) >= (${r})))`;
+    case BinaryOperation.AndAnd:
+      return `((double)(((${l}) != 0.0) && ((${r}) != 0.0)))`;
+    case BinaryOperation.OrOr:
+      return `((double)(((${l}) != 0.0) || ((${r}) != 0.0)))`;
+    default:
+      throw new Error(`cFusedCodegen: unsupported binary op ${expr.op}`);
+  }
+}
+
+function emitUnaryScalar(
+  expr: JitExpr & { tag: "Unary" },
+  chainLocals: ReadonlySet<string>,
+  allTensorVars: ReadonlySet<string>,
+  helpersNeeded: Set<string>
+): string {
+  const operand = emitScalarExpr(
+    expr.operand,
+    chainLocals,
+    allTensorVars,
+    helpersNeeded
+  );
+  switch (expr.op) {
+    case UnaryOperation.Plus:
+      return `(+${operand})`;
+    case UnaryOperation.Minus:
+      return `(-${operand})`;
+    case UnaryOperation.Not:
+      return `((double)((${operand}) == 0.0))`;
+    default:
+      throw new Error(`cFusedCodegen: unsupported unary op ${expr.op}`);
+  }
+}
+
+function emitCallScalar(
+  expr: JitExpr & { tag: "Call" },
+  chainLocals: ReadonlySet<string>,
+  allTensorVars: ReadonlySet<string>,
+  helpersNeeded: Set<string>
+): string {
+  // Tensor unary call → becomes scalar math call on the per-element value
+  if (
+    (expr.jitType.kind === "tensor" && expr.name in C_TENSOR_UNARY_OPS) ||
+    expr.name in BUILTIN_TO_C
+  ) {
+    const cName = BUILTIN_TO_C[expr.name];
+    if (!cName) {
+      throw new Error(`cFusedCodegen: unmapped builtin ${expr.name}`);
+    }
+    if (expr.name === "mod" || expr.name === "sign") {
+      helpersNeeded.add(expr.name);
+    }
+    const args = expr.args.map(a =>
+      emitScalarExpr(a, chainLocals, allTensorVars, helpersNeeded)
+    );
+    return `${cName}(${args.join(", ")})`;
+  }
+  throw new Error(
+    `cFusedCodegen: unsupported call in fused chain: ${expr.name}`
+  );
+}
+
+// ── Reduction init / combine helpers ─────────────────────────────────
+
+function reductionInit(reduceName: string): string {
+  switch (reduceName) {
+    case "sum":
+    case "mean":
+      return "0.0";
+    case "prod":
+      return "1.0";
+    case "max":
+      return "(-1.0/0.0)"; // -Inf
+    case "min":
+      return "(1.0/0.0)"; // +Inf
+    case "any":
+      return "0.0";
+    case "all":
+      return "1.0";
+    default:
+      throw new Error(`cFusedCodegen: unknown reduction ${reduceName}`);
+  }
+}
+
+function reductionCombine(
+  reduceName: string,
+  accVar: string,
+  valueExpr: string
+): string {
+  switch (reduceName) {
+    case "sum":
+    case "mean":
+      return `${accVar} += ${valueExpr};`;
+    case "prod":
+      return `${accVar} *= ${valueExpr};`;
+    case "max":
+      return `if (${valueExpr} > ${accVar}) ${accVar} = ${valueExpr};`;
+    case "min":
+      return `if (${valueExpr} < ${accVar}) ${accVar} = ${valueExpr};`;
+    case "any":
+      return `if (${valueExpr} != 0.0) ${accVar} = 1.0;`;
+    case "all":
+      return `if (${valueExpr} == 0.0) ${accVar} = 0.0;`;
+    default:
+      throw new Error(`cFusedCodegen: unknown reduction ${reduceName}`);
+  }
+}
+
+function accumulateOp(op: BinaryOperation, dest: string, val: string): string {
+  switch (op) {
+    case BinaryOperation.Add:
+      return `${dest} += ${val};`;
+    case BinaryOperation.Sub:
+      return `${dest} -= ${val};`;
+    case BinaryOperation.Mul:
+    case BinaryOperation.ElemMul:
+      return `${dest} *= ${val};`;
+    default:
+      return `${dest} = ${dest} + ${val};`; // fallback
+  }
+}
+
+// ── Public API ────────────────────────────────────────────────────────
+
+/**
+ * Emit a fused per-element loop for the given chain.
+ *
+ * Appends C source lines to `lines`. Returns the set of helper
+ * function names needed (e.g. "__numbl_mod") so the caller can emit
+ * their definitions.
+ *
+ * `allTensorVars` is the full set of tensor-typed variable names.
+ * `paramTensors` is the subset that are input parameters.
+ * `outputTensorNames` is the subset that are function outputs.
+ * `localTensorNames` is the subset that are non-param, non-output locals.
+ */
+export function emitFusedChain(
+  lines: string[],
+  indent: string,
+  chain: FusibleChain,
+  allTensorVars: ReadonlySet<string>,
+  paramTensors: ReadonlySet<string>,
+  outputTensorNames: ReadonlySet<string>,
+  localTensorNames: ReadonlySet<string>
+): Set<string> {
+  const helpersNeeded = new Set<string>();
+
+  // Determine the length variable — use the first tensor param referenced.
+  const lenVar = findLenVar(chain, paramTensors, allTensorVars);
+
+  // Determine which dest names need a write-back to their buffer.
+  // A dest needs write-back if:
+  //   1. It's an output or param-output tensor, OR
+  //   2. It's read after the chain (we conservatively always write back
+  //      unless the reduction fully consumes it)
+  // For simplicity: write back all distinct dest names EXCEPT one that
+  // is consumed solely by the trailing reduction.
+  const lastDest = chain.assigns[chain.assigns.length - 1].destName;
+  const reductionConsumes =
+    chain.reduction && chain.reduction.tensorName === lastDest;
+
+  // Collect distinct dest names that appear in the chain.
+  const destNames = new Set<string>();
+  for (const a of chain.assigns) destNames.add(a.destName);
+
+  // Determine which dests need write-back.
+  const writeBack = new Set<string>();
+  for (const d of destNames) {
+    if (reductionConsumes && d === lastDest) {
+      // Check if this dest is ALSO an output — if so, still write back.
+      if (outputTensorNames.has(d)) {
+        writeBack.add(d);
+      }
+      // Otherwise skip — the reduction consumes it.
+    } else {
+      writeBack.add(d);
+    }
+  }
+
+  // For dests that need write-back and are local tensors, ensure buffer
+  // is allocated before the loop.
+  for (const d of writeBack) {
+    if (localTensorNames.has(d)) {
+      lines.push(`${indent}${tensorLen(d)} = ${lenVar};`);
+      lines.push(
+        `${indent}if (!${tensorData(d)}) ${tensorData(d)} = (double *)malloc((size_t)${lenVar} * sizeof(double));`
+      );
+    }
+  }
+
+  // Emit reduction accumulator init.
+  const reduceAccLocal = "__f_reduce_acc";
+  if (chain.reduction) {
+    lines.push(
+      `${indent}double ${reduceAccLocal} = ${reductionInit(chain.reduction.reduceName)};`
+    );
+  }
+
+  // Track which tensor vars have been produced by earlier assigns in
+  // the chain — these are read via scalar locals, not array reads.
+  const chainLocals = new Set<string>();
+
+  // Open the fused loop.
+  if (!chain.reduction) {
+    lines.push(`${indent}#pragma omp simd`);
+  }
+  lines.push(`${indent}for (int64_t __i = 0; __i < ${lenVar}; __i++) {`);
+  const inner = indent + "  ";
+
+  for (const assign of chain.assigns) {
+    const rhs = emitScalarExpr(
+      assign.expr,
+      chainLocals,
+      allTensorVars,
+      helpersNeeded
+    );
+
+    // First assignment to this dest in the loop → declare the scalar local.
+    // Subsequent assignments → just reassign.
+    if (!chainLocals.has(assign.destName)) {
+      lines.push(`${inner}double ${fusedLocal(assign.destName)} = ${rhs};`);
+      chainLocals.add(assign.destName);
+    } else {
+      lines.push(`${inner}${fusedLocal(assign.destName)} = ${rhs};`);
+    }
+  }
+
+  // Write-back to buffers.
+  for (const d of writeBack) {
+    lines.push(`${inner}${tensorData(d)}[__i] = ${fusedLocal(d)};`);
+  }
+
+  // Inline reduction accumulate.
+  if (chain.reduction) {
+    const valueExpr = fusedLocal(chain.reduction.tensorName);
+    lines.push(
+      `${inner}${reductionCombine(chain.reduction.reduceName, reduceAccLocal, valueExpr)}`
+    );
+  }
+
+  // Close the loop.
+  lines.push(`${indent}}`);
+
+  // Update tensor lengths for write-back dests.
+  for (const d of writeBack) {
+    lines.push(`${indent}${tensorLen(d)} = ${lenVar};`);
+  }
+
+  // Post-loop: apply mean division if needed, then store reduction result.
+  if (chain.reduction) {
+    if (chain.reduction.reduceName === "mean") {
+      lines.push(`${indent}${reduceAccLocal} /= (double)${lenVar};`);
+    }
+    const acc = mangle(chain.reduction.accName);
+    if (chain.reduction.hasAccumulate && chain.reduction.accOp !== undefined) {
+      lines.push(
+        `${indent}${accumulateOp(chain.reduction.accOp, acc, reduceAccLocal)}`
+      );
+    } else {
+      lines.push(`${indent}${acc} = ${reduceAccLocal};`);
+    }
+  }
+
+  return helpersNeeded;
+}
+
+/**
+ * Find a tensor length C expression to use as the loop bound.
+ * Walks the first chain assign's expression tree to find a tensor param
+ * reference, then returns its `_len` variable.
+ */
+function findLenVar(
+  chain: FusibleChain,
+  paramTensors: ReadonlySet<string>,
+  allTensorVars: ReadonlySet<string>
+): string {
+  // Try to find a param tensor reference in the chain's expressions.
+  for (const a of chain.assigns) {
+    const found = findTensorParamInExpr(a.expr, paramTensors, allTensorVars);
+    if (found) return tensorLen(found);
+  }
+  // Fallback: use the first dest's length (it must be set from somewhere).
+  return tensorLen(chain.assigns[0].destName);
+}
+
+function findTensorParamInExpr(
+  expr: JitExpr,
+  paramTensors: ReadonlySet<string>,
+  allTensorVars: ReadonlySet<string>
+): string | null {
+  if (expr.tag === "Var" && allTensorVars.has(expr.name)) {
+    if (paramTensors.has(expr.name)) return expr.name;
+    return null; // chain-produced, doesn't have a _len
+  }
+  if (expr.tag === "Binary") {
+    return (
+      findTensorParamInExpr(expr.left, paramTensors, allTensorVars) ??
+      findTensorParamInExpr(expr.right, paramTensors, allTensorVars)
+    );
+  }
+  if (expr.tag === "Unary") {
+    return findTensorParamInExpr(expr.operand, paramTensors, allTensorVars);
+  }
+  if (expr.tag === "Call") {
+    for (const a of expr.args) {
+      const f = findTensorParamInExpr(a, paramTensors, allTensorVars);
+      if (f) return f;
+    }
+  }
+  return null;
+}

--- a/src/numbl-core/interpreter/jit/c/cFusion.ts
+++ b/src/numbl-core/interpreter/jit/c/cFusion.ts
@@ -1,0 +1,265 @@
+/**
+ * Fusion analysis for the C-JIT codegen.
+ *
+ * Scans a statement list for runs of tensor element-wise assigns that
+ * can be collapsed into a single per-element `for` loop. Each such run
+ * is a "fusible chain."
+ *
+ * A chain breaks on:
+ *   - control flow (If/For/While)
+ *   - any non-Assign statement
+ *   - a tensor assign whose RHS references a tensor that is NOT an input
+ *     param and NOT previously assigned within the same chain
+ *   - a scalar assign (left for the per-op emitter)
+ *
+ * An optional **trailing reduction** is absorbed when the statement
+ * immediately after a tensor chain is of the form
+ *   `acc = acc + reduce(lastChainVar)`   or
+ *   `acc = reduce(lastChainVar)`
+ * where `reduce` is sum/prod/max/min/mean/any/all. Absorbing the
+ * reduction lets the fused loop emit an inline accumulator instead of
+ * materialising the intermediate buffer.
+ */
+
+import type { JitExpr, JitStmt } from "../jitTypes.js";
+import { BinaryOperation } from "../../../parser/types.js";
+import { C_TENSOR_UNARY_OPS, C_TENSOR_REDUCTION_OPS } from "./cFeasibility.js";
+
+// ── Public types ──────────────────────────────────────────���──────────
+
+/** One tensor assign inside a fusible chain. */
+export interface FusedAssign {
+  /** Destination tensor variable name. */
+  destName: string;
+  /** RHS expression tree (all tensor ops are element-wise). */
+  expr: JitExpr;
+}
+
+/** A trailing reduction absorbed into the fused loop. */
+export interface FusedReduction {
+  /** Scalar accumulator variable name (e.g. `chain_acc`). */
+  accName: string;
+  /** Reduction builtin name (e.g. `sum`). */
+  reduceName: string;
+  /** The tensor variable being reduced (last chain dest). */
+  tensorName: string;
+  /**
+   * When true, the scalar statement is `acc = acc OP reduce(tensor)`,
+   * and `accOp` says which binary op combines the old accumulator with
+   * the reduction result. When false, it's a plain `acc = reduce(tensor)`.
+   */
+  hasAccumulate: boolean;
+  accOp?: BinaryOperation;
+}
+
+/** Describes one fusible chain found in a statement list. */
+export interface FusibleChain {
+  /** Index of the first statement in the chain (within the parent list). */
+  startIdx: number;
+  /** Number of statements consumed (tensor assigns + optional reduction). */
+  length: number;
+  /** The tensor assigns to fuse. */
+  assigns: FusedAssign[];
+  /** Optional trailing reduction. */
+  reduction?: FusedReduction;
+}
+
+// ── Analysis ─────────────────────────────────────────────────────────
+
+/**
+ * Returns true when the expression tree is a pure tensor element-wise
+ * computation: every tensor reference is either a known variable from
+ * `knownTensors` or an input param from `paramTensors`, and every op
+ * is element-wise (Binary +−×÷ / comparisons, Unary ±, tensor Call).
+ */
+function isPureElementwise(
+  expr: JitExpr,
+  paramTensors: ReadonlySet<string>,
+  knownTensors: ReadonlySet<string>
+): boolean {
+  switch (expr.tag) {
+    case "NumberLiteral":
+      return true;
+
+    case "Var":
+      if (expr.jitType.kind === "tensor") {
+        return paramTensors.has(expr.name) || knownTensors.has(expr.name);
+      }
+      // scalar var — ok
+      return true;
+
+    case "Binary": {
+      // All binary ops that feasibility already accepted are fine for
+      // fusion as long as both children are pure.
+      return (
+        isPureElementwise(expr.left, paramTensors, knownTensors) &&
+        isPureElementwise(expr.right, paramTensors, knownTensors)
+      );
+    }
+
+    case "Unary":
+      return isPureElementwise(expr.operand, paramTensors, knownTensors);
+
+    case "Call": {
+      // Tensor unary calls (exp, sin, etc.)
+      if (expr.jitType.kind === "tensor" && expr.name in C_TENSOR_UNARY_OPS) {
+        return expr.args.every(a =>
+          isPureElementwise(a, paramTensors, knownTensors)
+        );
+      }
+      // Scalar math calls (sin of a scalar, etc.)
+      if (expr.jitType.kind !== "tensor") {
+        return expr.args.every(a =>
+          isPureElementwise(a, paramTensors, knownTensors)
+        );
+      }
+      return false;
+    }
+
+    default:
+      return false;
+  }
+}
+
+/**
+ * Attempt to recognise a trailing reduction that can be absorbed into
+ * the fused loop. Patterns:
+ *   `acc = acc + sum(tensorVar)`
+ *   `acc = sum(tensorVar)`
+ *
+ * `tensorVar` must be the last tensor assigned in the chain.
+ */
+function tryMatchReduction(
+  stmt: JitStmt,
+  lastChainDest: string
+): FusedReduction | null {
+  if (stmt.tag !== "Assign") return null;
+  const expr = stmt.expr;
+
+  // Pattern 1: acc = reduce(tensor)
+  if (
+    expr.tag === "Call" &&
+    expr.name in C_TENSOR_REDUCTION_OPS &&
+    expr.args.length === 1 &&
+    expr.args[0].tag === "Var" &&
+    expr.args[0].name === lastChainDest
+  ) {
+    return {
+      accName: stmt.name,
+      reduceName: expr.name,
+      tensorName: lastChainDest,
+      hasAccumulate: false,
+    };
+  }
+
+  // Pattern 2: acc = acc OP reduce(tensor)
+  if (expr.tag === "Binary") {
+    // Check left = Var(acc), right = Call(reduce, tensor)
+    if (
+      expr.left.tag === "Var" &&
+      expr.left.name === stmt.name &&
+      expr.right.tag === "Call" &&
+      expr.right.name in C_TENSOR_REDUCTION_OPS &&
+      expr.right.args.length === 1 &&
+      expr.right.args[0].tag === "Var" &&
+      expr.right.args[0].name === lastChainDest
+    ) {
+      return {
+        accName: stmt.name,
+        reduceName: expr.right.name,
+        tensorName: lastChainDest,
+        hasAccumulate: true,
+        accOp: expr.op,
+      };
+    }
+    // Check right = Var(acc), left = Call(reduce, tensor)
+    if (
+      expr.right.tag === "Var" &&
+      expr.right.name === stmt.name &&
+      expr.left.tag === "Call" &&
+      expr.left.name in C_TENSOR_REDUCTION_OPS &&
+      expr.left.args.length === 1 &&
+      expr.left.args[0].tag === "Var" &&
+      expr.left.args[0].name === lastChainDest
+    ) {
+      return {
+        accName: stmt.name,
+        reduceName: expr.left.name,
+        tensorName: lastChainDest,
+        hasAccumulate: true,
+        accOp: expr.op,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Scan a statement list and return all fusible chains.
+ *
+ * `paramTensors` is the set of tensor parameter names (input data that
+ * will be read via `data[i]` in the fused loop).
+ * `allTensorVars` is the full set of tensor-typed variables (params +
+ * locals + outputs).
+ */
+export function findFusibleChains(
+  stmts: JitStmt[],
+  paramTensors: ReadonlySet<string>,
+  allTensorVars: ReadonlySet<string>
+): FusibleChain[] {
+  const chains: FusibleChain[] = [];
+  let i = 0;
+
+  while (i < stmts.length) {
+    const chainAssigns: FusedAssign[] = [];
+    const chainStart = i;
+    // Tensor vars produced so far in this chain.
+    const produced = new Set<string>();
+
+    while (i < stmts.length) {
+      const s = stmts[i];
+      // Skip SetLoc (line-number tracking) — it's a no-op.
+      if (s.tag === "SetLoc") {
+        i++;
+        continue;
+      }
+      if (s.tag !== "Assign") break;
+      if (!allTensorVars.has(s.name)) break;
+      if (s.expr.jitType.kind !== "tensor") break;
+      if (!isPureElementwise(s.expr, paramTensors, produced)) break;
+
+      chainAssigns.push({ destName: s.name, expr: s.expr });
+      produced.add(s.name);
+      i++;
+    }
+
+    if (chainAssigns.length >= 2) {
+      // Check for trailing reduction (skip any SetLoc first).
+      while (i < stmts.length && stmts[i].tag === "SetLoc") i++;
+      let reduction: FusedReduction | undefined;
+      const lastDest = chainAssigns[chainAssigns.length - 1].destName;
+      if (i < stmts.length) {
+        const r = tryMatchReduction(stmts[i], lastDest);
+        if (r) {
+          reduction = r;
+          i++;
+        }
+      }
+
+      chains.push({
+        startIdx: chainStart,
+        length: i - chainStart,
+        assigns: chainAssigns,
+        reduction,
+      });
+    } else {
+      // Not enough to fuse — skip one statement.
+      if (chainAssigns.length === 0) i++;
+      // If chainAssigns.length === 1, `i` already advanced past it;
+      // it will be emitted by the per-op path.
+    }
+  }
+
+  return chains;
+}

--- a/src/numbl-core/interpreter/jit/c/jitCodegenC.ts
+++ b/src/numbl-core/interpreter/jit/c/jitCodegenC.ts
@@ -18,6 +18,8 @@
 import { BinaryOperation, UnaryOperation } from "../../../parser/types.js";
 import type { JitExpr, JitStmt, JitType } from "../jitTypes.js";
 import { C_TENSOR_REDUCTION_OPS, C_TENSOR_UNARY_OPS } from "./cFeasibility.js";
+import { findFusibleChains } from "./cFusion.js";
+import { emitFusedChain } from "./cFusedCodegen.js";
 
 const MANGLE_PREFIX = "v_";
 
@@ -160,6 +162,10 @@ interface EmitCtx {
   /** When set, expression emission can prepend statements (e.g. for
    *  reductions of complex tensor expressions that need scratch buffers). */
   pendingStmts?: { lines: string[]; indent: string };
+  /** Emit fused per-element loops for tensor chains (--fuse). */
+  fuse: boolean;
+  /** Tensor parameter names (for fusion analysis). */
+  paramTensorNames: Set<string>;
 }
 
 // ── Expression emission ───────────────────────────────────────────────
@@ -516,7 +522,44 @@ function emitStmts(
   indent: string,
   ctx: EmitCtx
 ): void {
-  for (const s of stmts) emitStmt(lines, s, indent, ctx);
+  if (!ctx.fuse) {
+    for (const s of stmts) emitStmt(lines, s, indent, ctx);
+    return;
+  }
+
+  // Fusion enabled: find fusible chains, emit them as fused loops,
+  // emit everything else via the per-op path.
+  const chains = findFusibleChains(stmts, ctx.paramTensorNames, ctx.tensorVars);
+
+  // Build a set of statement indices covered by chains.
+  const coveredByChain = new Map<
+    number,
+    { chain: ReturnType<typeof findFusibleChains>[0] }
+  >();
+  for (const chain of chains) {
+    coveredByChain.set(chain.startIdx, { chain });
+  }
+
+  let i = 0;
+  while (i < stmts.length) {
+    const entry = coveredByChain.get(i);
+    if (entry) {
+      const helpers = emitFusedChain(
+        lines,
+        indent,
+        entry.chain,
+        ctx.tensorVars,
+        ctx.paramTensorNames,
+        ctx.outputTensorNames,
+        ctx.localTensorNames
+      );
+      for (const h of helpers) ctx.helpersNeeded.add(h);
+      i += entry.chain.length;
+    } else {
+      emitStmt(lines, stmts[i], indent, ctx);
+      i++;
+    }
+  }
 }
 
 /** For local tensor dests (not output, not param), ensure the buffer
@@ -783,7 +826,8 @@ export function generateC(
   argTypes: JitType[],
   _outputType: JitType | null,
   outputTypes: JitType[],
-  fnName: string
+  fnName: string,
+  fuse?: boolean
 ): GenerateCResult {
   if (params.length !== argTypes.length) {
     throw new Error("C-JIT codegen: params/argTypes length mismatch");
@@ -829,6 +873,8 @@ export function generateC(
     usedScratch: new Set(),
     freeStmts: [],
     localTensorNames,
+    fuse: fuse ?? false,
+    paramTensorNames,
   };
 
   const indent = "  ";

--- a/src/numbl-core/interpreter/jit/cJitInstall.ts
+++ b/src/numbl-core/interpreter/jit/cJitInstall.ts
@@ -53,7 +53,8 @@ registerCJitBackend({
         argTypes,
         outputType,
         outputTypes,
-        fn.name.replace(/[^A-Za-z0-9_]/g, "_")
+        fn.name.replace(/[^A-Za-z0-9_]/g, "_"),
+        interp.fuse
       );
     } catch {
       return null;


### PR DESCRIPTION
## Summary
- Add `--fuse` flag that collapses consecutive tensor element-wise assigns into a single
  per-element `for` loop with inline scalar expressions — no libnumbl_ops calls, no
  intermediate buffers.
- Trailing reductions (`acc += sum(r)`) are absorbed as inline accumulators.
- Also adds `-fopenmp-simd -ffast-math` to C-JIT compile flags for SIMD vectorization.

## Results (N=2M, 50 trials, median of 3)

| Mode             | Total  | Binary | Unary  |
|------------------|-------:|-------:|-------:|
| `--opt 2`        | 3.09 s | 0.66 s | 1.34 s |
| `--opt 2 --fuse` | 1.56 s | 0.10 s | 0.57 s |
| MATLAB R2025b    | 2.86 s | 0.29 s | 1.82 s |

## Test plan
- [ ] `npm test` — all 1457 unit + 655 integration tests pass
- [ ] `--opt 2` integration tests pass (no regression from new compile flags)
- [ ] `--opt 2 --fuse` benchmark check values match MATLAB