### PR TITLE
jit/c: explicit complex binary opcode map (#38)

### DIFF
--- a/src/numbl-core/jit/c/context.ts
+++ b/src/numbl-core/jit/c/context.ts
@@ -112,6 +112,19 @@ export const TENSOR_BIN_OP: Partial<Record<BinaryOperation, string>> = {
   [BinaryOperation.ElemDiv]: "NUMBL_REAL_BIN_DIV",
 };
 
+// Binary op → libnumbl_ops complex opcode enum name. Kept as an explicit
+// map (rather than string-replacing "REAL" → "COMPLEX" on TENSOR_BIN_OP)
+// so divergence between the real and complex enums in numbl_ops.h would
+// surface as a missing entry here rather than silently emit a wrong symbol.
+export const TENSOR_COMPLEX_BIN_OP: Partial<Record<BinaryOperation, string>> = {
+  [BinaryOperation.Add]: "NUMBL_COMPLEX_BIN_ADD",
+  [BinaryOperation.Sub]: "NUMBL_COMPLEX_BIN_SUB",
+  [BinaryOperation.Mul]: "NUMBL_COMPLEX_BIN_MUL",
+  [BinaryOperation.ElemMul]: "NUMBL_COMPLEX_BIN_MUL",
+  [BinaryOperation.Div]: "NUMBL_COMPLEX_BIN_DIV",
+  [BinaryOperation.ElemDiv]: "NUMBL_COMPLEX_BIN_DIV",
+};
+
 // Binary comparison op → libnumbl_ops opcode enum name.
 export const TENSOR_CMP_OP: Partial<Record<BinaryOperation, string>> = {
   [BinaryOperation.Equal]: "NUMBL_CMP_EQ",

--- a/src/numbl-core/jit/c/emit/tensor.ts
+++ b/src/numbl-core/jit/c/emit/tensor.ts
@@ -39,6 +39,7 @@ import {
   tensorDataIm,
   tensorLen,
   TENSOR_BIN_OP,
+  TENSOR_COMPLEX_BIN_OP,
   TENSOR_CMP_OP,
   getTensorUnaryOp,
   type EmitCtx,
@@ -552,16 +553,12 @@ export function emitComplexTensorBinaryStmts(
   destDataImVar: string,
   destLenVar: string
 ): void {
-  const opEnum = TENSOR_BIN_OP[expr.op];
-  if (!opEnum) {
+  const complexOpEnum = TENSOR_COMPLEX_BIN_OP[expr.op];
+  if (!complexOpEnum) {
     throw new Error(
       `C-JIT codegen: complex tensor binary op ${expr.op} has no opcode`
     );
   }
-  // TENSOR_BIN_OP enum values are numerically aligned with the
-  // NUMBL_COMPLEX_BIN_* enum (ADD=0, SUB=1, MUL=2, DIV=3), so the same
-  // string works at the C-side switch. Confirmed by numbl_ops.h.
-  const complexOpEnum = opEnum.replace("NUMBL_REAL_BIN_", "NUMBL_COMPLEX_BIN_");
 
   const leftIsTensor = isTensorExpr(expr.left);
   const rightIsTensor = isTensorExpr(expr.right);


### PR DESCRIPTION
## Summary
- Add an explicit `TENSOR_COMPLEX_BIN_OP` map alongside `TENSOR_BIN_OP` in `context.ts`.
- Replace the `opEnum.replace("NUMBL_REAL_BIN_", "NUMBL_COMPLEX_BIN_")` remap in `emit/tensor.ts` with a direct lookup.
- If the real and complex enums in `numbl_ops.h` ever diverge or get reordered, this surfaces as a missing-entry throw rather than silently emitting a wrong opcode symbol.

Fixes #38.

## Test plan
- [x] `npm test`