### PR TITLE
jit/c: guard shapeExprsFor against zero known dim (#39)

### DIFF
--- a/src/numbl-core/jit/c/emit/tensor.ts
+++ b/src/numbl-core/jit/c/emit/tensor.ts
@@ -117,8 +117,11 @@ export function shapeExprsFor(
   const shape =
     shapeSrc?.jitType.kind === "tensor" ? shapeSrc.jitType.shape : undefined;
   if (shape && shape.length === 2) {
-    const d0Known = shape[0] !== -1;
-    const d1Known = shape[1] !== -1;
+    // Treat 0 the same as unknown (-1): dividing lenExpr by 0 would be UB
+    // in the emitted C. Feasibility normally excludes zero-dim tensors;
+    // guard here defensively.
+    const d0Known = shape[0] !== -1 && shape[0] !== 0;
+    const d1Known = shape[1] !== -1 && shape[1] !== 0;
     if (d0Known && d1Known) return [`${shape[0]}`, `${shape[1]}`];
     if (d0Known) return [`${shape[0]}`, `(${lenExpr} / ${shape[0]})`];
     if (d1Known) return [`(${lenExpr} / ${shape[1]})`, `${shape[1]}`];


### PR DESCRIPTION
## Summary
- In \`shapeExprsFor\`, treat a statically-known shape dim of \`0\` the same as unknown (\`-1\`) to avoid emitting \`(lenExpr / 0)\` in the generated C (UB).
- Feasibility normally excludes zero-dim tensors; this is a defensive guard at the emit boundary.

Fixes #39.

## Test plan
- [x] \`npm test\` (one unrelated worktree-side network flake on \`test_webread.m\`)