### PR TITLE
jit/c: wrap emitUserCallTensorAssign arg marshaling in withPendingStmts (#41)

### DIFF
--- a/src/numbl-core/jit/c/emit/userCall.ts
+++ b/src/numbl-core/jit/c/emit/userCall.ts
@@ -34,6 +34,7 @@ import {
 } from "../context.js";
 import { emitComplex } from "./complexScalar.js";
 import { emitExpr } from "./scalar.js";
+import { withPendingStmts } from "./stmt.js";
 
 /** Emit the C expressions for one arg's ABI slots, consulting the
  *  callee's paramDesc so the slot order matches the callee's signature.
@@ -206,15 +207,24 @@ export function emitUserCallTensorAssign(
     );
   }
   ctx.needsErrorFlag = true;
-  const argCodes: string[] = [];
-  for (let i = 0; i < expr.args.length; i++) {
-    const slots = emitUserCallArgSlots(
-      expr.args[i],
-      calleeAbi.paramDescs[i],
-      ctx
-    );
-    argCodes.push(...slots);
-  }
+  // Marshal args inside a pendingStmts frame so a complex scalar arg
+  // whose expression needs materialized pair locals (e.g. `(1+2i)*z`)
+  // can hoist its decls into `lines` ahead of the callee invocation.
+  // emitComplexTensorAssign wraps its caller path, but the real-tensor
+  // emitTensorAssign path into this function does not — wrapping here
+  // makes the function self-sufficient.
+  const argCodes: string[] = withPendingStmts(ctx, lines, indent, () => {
+    const codes: string[] = [];
+    for (let i = 0; i < expr.args.length; i++) {
+      const slots = emitUserCallArgSlots(
+        expr.args[i],
+        calleeAbi.paramDescs[i],
+        ctx
+      );
+      codes.push(...slots);
+    }
+    return codes;
+  });
   const dData = tensorData(destName);
   const dLen = tensorLen(destName);
   const dD0 = tensorD0(destName);


### PR DESCRIPTION
## Summary
- Audit of \`materializeComplexPair\` / \`emitComplex\` entry points found one path that was not wrapped in a \`pendingStmts\` frame: \`emitUserCallTensorAssign\` via the real-tensor \`emitTensorAssign\` caller.
- A real-tensor-return user function can accept \`complex_or_number\` scalar params. A call like \`y = foo(x, (1+2i)*z)\` reaches \`emitUserCallArgSlots → emitComplex\` on a complex \`Binary\`, which needs a frame to hoist pair-local decls.
- Previously this would throw \`"materializeComplexPair outside statement context"\`, caught by \`cJitInstall\`'s fallback. The fix makes the function self-sufficient rather than relying on an implicit caller contract.

Fixes #41.

## Test plan
- [x] \`npm test\`