### PR TITLE
jit/c: free first scratch buffer on second malloc failure (#43)

### DIFF
--- a/src/numbl-core/jit/c/emit/tensor.ts
+++ b/src/numbl-core/jit/c/emit/tensor.ts
@@ -98,7 +98,15 @@ export function emitScratchBufAllocComplex(
   lines.push(
     `${inner}  ${sDataIm} = (__need > 0) ? (double *)malloc((size_t)__need * sizeof(double)) : NULL;`
   );
-  lines.push(`${inner}  ${sLen} = __need;`);
+  // If the second malloc failed (OOM), free the first so we don't leak,
+  // and zero sLen so downstream sees "no scratch" rather than a stale size.
+  lines.push(`${inner}  if (__need > 0 && ${sDataIm} == NULL && ${sData}) {`);
+  lines.push(`${inner}    free(${sData});`);
+  lines.push(`${inner}    ${sData} = NULL;`);
+  lines.push(`${inner}    ${sLen} = 0;`);
+  lines.push(`${inner}  } else {`);
+  lines.push(`${inner}    ${sLen} = __need;`);
+  lines.push(`${inner}  }`);
   lines.push(`${inner}}`);
   lines.push(`${indent}}`);
 }


### PR DESCRIPTION
## Summary
- \`emitScratchBufAllocComplex\` allocates re + im buffers separately. If the first malloc succeeded but the second returned NULL (OOM), the first buffer was leaked.
- Emit a cleanup branch that \`free\`s the first buffer, nulls it, and zeros \`sLen\` on that path so downstream sees "no scratch" instead of a stale size.
- Low impact in practice (OOM is effectively fatal), but matching cleanup keeps the allocator invariants tidy.

Fixes #43.

## Test plan
- [x] \`npm test\` (one unrelated worktree-side network flake on \`test_fread.m\`)