### PR TITLE
jit/c: read NUMBL_OMP_THRESHOLD at emit time (#44)

### DIFF
--- a/src/__tests__/c-jit-smoke.test.ts
+++ b/src/__tests__/c-jit-smoke.test.ts
@@ -518,6 +518,88 @@ describe("C-JIT: tensor codegen (Phase 2, koffi)", () => {
   });
 });
 
+describe("C-JIT: NUMBL_OMP_THRESHOLD is read at emit time", () => {
+  const tensor1dT: JitType = {
+    kind: "tensor",
+    isComplex: false,
+    shape: [100, 1],
+  };
+
+  // r = exp(x) + sin(x)  — heavy ops, tensor output → parallel-for candidate.
+  const body: JitStmt[] = [
+    {
+      tag: "Assign",
+      name: "r",
+      expr: {
+        tag: "Binary",
+        op: BinaryOperation.Add,
+        left: {
+          tag: "Call",
+          name: "exp",
+          args: [{ tag: "Var", name: "x", jitType: tensor1dT }],
+          jitType: tensor1dT,
+        },
+        right: {
+          tag: "Call",
+          name: "sin",
+          args: [{ tag: "Var", name: "x", jitType: tensor1dT }],
+          jitType: tensor1dT,
+        },
+        jitType: tensor1dT,
+      },
+    },
+  ];
+
+  const emit = () =>
+    generateC(
+      body,
+      ["x"],
+      ["r"],
+      1,
+      new Set(["r"]),
+      [tensor1dT],
+      tensor1dT,
+      [tensor1dT],
+      "fn_omp",
+      true, // fuse
+      true // openmp
+    ).cSource;
+
+  it("reflects updated env var across two emits in the same process", () => {
+    const original = process.env.NUMBL_OMP_THRESHOLD;
+    try {
+      process.env.NUMBL_OMP_THRESHOLD = "1234";
+      const a = emit();
+      expect(a).toContain("if(v_x_len >= 1234)");
+
+      process.env.NUMBL_OMP_THRESHOLD = "5678";
+      const b = emit();
+      expect(b).toContain("if(v_x_len >= 5678)");
+      expect(b).not.toContain("if(v_x_len >= 1234)");
+    } finally {
+      if (original === undefined) delete process.env.NUMBL_OMP_THRESHOLD;
+      else process.env.NUMBL_OMP_THRESHOLD = original;
+    }
+  });
+
+  it("falls back to 100000 when env var is empty or non-numeric", () => {
+    const original = process.env.NUMBL_OMP_THRESHOLD;
+    try {
+      process.env.NUMBL_OMP_THRESHOLD = "";
+      expect(emit()).toContain("if(v_x_len >= 100000)");
+      process.env.NUMBL_OMP_THRESHOLD = "not-a-number";
+      expect(emit()).toContain("if(v_x_len >= 100000)");
+      // "0" is falsy after parseInt, so it falls back to the default.
+      // Preserved intentionally — matches pre-fix behaviour.
+      process.env.NUMBL_OMP_THRESHOLD = "0";
+      expect(emit()).toContain("if(v_x_len >= 100000)");
+    } finally {
+      if (original === undefined) delete process.env.NUMBL_OMP_THRESHOLD;
+      else process.env.NUMBL_OMP_THRESHOLD = original;
+    }
+  });
+});
+
 describe("C-JIT: tensor parity with JS-JIT (E2E)", () => {
   const available = E2E_ENABLED && hasCc();
   const itSkipWithoutCc = available ? it : it.skip;

--- a/src/numbl-core/jit/c/emit/fused.ts
+++ b/src/numbl-core/jit/c/emit/fused.ts
@@ -50,9 +50,14 @@ import {
 } from "../../fusedChainHelpers.js";
 
 /** Minimum element count before `#pragma omp parallel for` kicks in.
- *  Below this, thread-spawn overhead dominates. */
-const OMP_PARALLEL_THRESHOLD =
-  parseInt(process.env.NUMBL_OMP_THRESHOLD || "", 10) || 100_000;
+ *  Below this, thread-spawn overhead dominates.
+ *
+ *  Read at emit time (not module-load) so a test or program that changes
+ *  NUMBL_OMP_THRESHOLD across runs in the same Node process sees the
+ *  updated value. */
+function ompParallelThreshold(): number {
+  return parseInt(process.env.NUMBL_OMP_THRESHOLD || "", 10) || 100_000;
+}
 
 /** Builtins that are expensive enough per element to justify thread-spawn overhead. */
 const HEAVY_OPS = new Set([
@@ -289,7 +294,7 @@ function emitRealFusedChain(
   if (!chain.reduction) {
     if (openmp && writesToOutput && heavyOps > 0) {
       lines.push(
-        `${indent}#pragma omp parallel for simd if(${lenVar} >= ${OMP_PARALLEL_THRESHOLD})`
+        `${indent}#pragma omp parallel for simd if(${lenVar} >= ${ompParallelThreshold()})`
       );
     } else {
       lines.push(`${indent}#pragma omp simd`);


### PR DESCRIPTION
## Summary
- Replace the module-load constant \`OMP_PARALLEL_THRESHOLD\` with an \`ompParallelThreshold()\` accessor that re-reads \`process.env.NUMBL_OMP_THRESHOLD\` on each call.
- Tests or programs changing the env var across runs in the same Node process now see the updated value, instead of the one baked in at first import.
- Preserves the exact \`parseInt(… || "", 10) || 100_000\` fallback semantics: empty / non-numeric / \`"0"\` all still default to 100000.
- Adds two unit tests in \`c-jit-smoke.test.ts\` covering the dynamic-read case and the fallback paths.

Fixes #44.

## Test plan
- [x] \`npm test\`