### PR TITLE
Refcount-driven pool reclamation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,7 @@ jobs:
         run: npm run build
 
       - name: Run tests (float64)
-        run: npm run test:float64
-
-      - name: Run tests (scripts)
-        run: npm run test:scripts
+        run: npm run test
 
   test-browser:
     name: Test Browser (Playwright)

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -141,6 +141,12 @@ Options (for run and eval):
                      (default is on: libmvec-vectorized transcendentals,
                      reductions reorder-allowed; opt out for
                      bitwise-deterministic FP semantics)
+  --no-mem-pool      Disable buffer reuse from the per-runtime memory pool
+                     (default is on: refcounted Float64Array buffers are
+                     released to the pool and reused on next allocation;
+                     opt out to make every allocation a fresh
+                     new Float64Array, isolating bugs that may stem from
+                     buffer recycling)
 
 Environment variables:
   NUMBL_PATH              Extra workspace directories (separated by :)

--- a/docs/developer_reference/overview.md
+++ b/docs/developer_reference/overview.md
@@ -42,6 +42,7 @@ A single entry point (the `executeCode` function) accepts source, options, and a
 - [jit/fusion.md](jit/fusion.md) — element-wise fusion.
 - [jit/cjit.md](jit/cjit.md) — C-JIT (`--opt e3`): what it's for and the three trigger contexts.
 - [runtime/values-and-tensors.md](runtime/values-and-tensors.md) — `RuntimeValue`, tensors, memory layout.
+- [runtime/refcount.md](runtime/refcount.md) — refcount-driven pool reclamation, slot ownership, transient scopes.
 - [runtime/native-addon.md](runtime/native-addon.md) — LAPACK/FFTW bindings and JS fallbacks.
 - [builtins.md](builtins.md) — the `IBuiltin` registry, resolution, JIT emission.
 - [stdlib.md](stdlib.md) — `.m`-defined standard library and bundle generation.

--- a/docs/developer_reference/runtime/refcount.md
+++ b/docs/developer_reference/runtime/refcount.md
@@ -1,0 +1,86 @@
+# Refcount and Pool Reclamation
+
+The runtime tracks reference counts on every container kind so that `Float64Array` buffers are released back to the per-runtime memory pool when their owning wrapper is no longer reachable. Strict ownership is enforced by an API on the container classes; the surrounding interpreter, JIT, and store paths thread the runtime through so every binding mutation goes through the API.
+
+This system is for **pool reclamation only**. Copy-on-write decisions still go through the sweep in [`runtime/aliasing.ts`](../../../src/numbl-core/runtime/aliasing.ts); refcount being slightly off is a leak or, in `poolReclaim` mode, a premature buffer release — never silent data corruption from missed COW.
+
+## `Refcounted`
+
+Defined in [`runtime/refcount.ts`](../../../src/numbl-core/runtime/refcount.ts). Every container class (`RuntimeTensor`, `RuntimeStruct`, `RuntimeCell`, …) extends `Refcounted`:
+
+- `_rc: number` — starts at 0. A "newborn" wrapper is owned by no slot.
+- `incref()` — bumps `_rc`.
+- `decref(rt)` — decrements; if the count hits 0, runs `_destroy(rt)`.
+- `_destroy(rt)` — kind-specific. Tensors and sparse matrices release their `Float64Array` buffers via `rt.pool.release(...)` (gated by `rt.poolReclaim`). Containers with child refs decref each child.
+
+The free helpers `incref(v)` and `decref(rt, v)` are noops on primitives (`number | boolean | string`).
+
+A constructor finalizer auto-adopts the new wrapper into the active runtime's `currentScope` (see [Transients](#transients) below). Tests that build `RuntimeValue`s without an active runtime are unaffected (`getCurrentRuntime()` returns null and adoption is skipped).
+
+## Slot ownership
+
+Every "slot" — env binding, struct field, cell element, function capture, dictionary entry, persistent / global — increfs the value when it takes ownership and decrefs the previous occupant when it's overwritten.
+
+- **`Environment.set` / `setLocal` / `clearLocals` / `delete`** ([`interpreter/types.ts`](../../../src/numbl-core/interpreter/types.ts)) — incref new before decref old, so self-rebind is safe.
+- **`Environment.snapshot()`** — increfs every value copied into the new flat env so anonymous-function closures survive the source frame's exit.
+- **`Runtime.setPersistent`** ([`runtime/runtime.ts`](../../../src/numbl-core/runtime/runtime.ts)) — same pattern for persistent variables.
+- **Container constructors** ([`runtime/types.ts`](../../../src/numbl-core/runtime/types.ts)) — `RuntimeStruct`, `RuntimeCell`, `RuntimeClassInstance`, `RuntimeFunction`, etc. incref every child value they accept at construction.
+- **`bindField` / `bindElement`** — class methods on `RuntimeStruct`, `RuntimeClassInstance`, `RuntimeCell` for in-place mutation. Used by `setRTValueField` (handle-class branch) and `storeIntoCell*` (every direct write to `cell.data[i]` and every auto-grow append routes through `setCellElement` / `appendEmptyCellSlot`).
+- **`callSuperConstructor`** ([`runtime/runtimeDispatch.ts`](../../../src/numbl-core/runtime/runtimeDispatch.ts)) — class-to-class inheritance threads `bindField`; the built-in-superclass case decrefs the old `_builtinData` and increfs the new one.
+
+`rt._envStack` (caller envs walked by the alias sweep across function boundaries) is a _borrowed_ reference — no incref. The slot-owning env still holds the count.
+
+## Transients
+
+A `RefScope` ([`runtime/refcount.ts`](../../../src/numbl-core/runtime/refcount.ts)) is established per top-level statement via `Runtime.withScope(fn)`. Every fresh container's auto-adopt routes into the active scope (`rc 0 → 1`). On scope drain at end of statement, every adopted value is decref'd:
+
+- Values bound to a slot during the statement got an extra incref from the slot, so they survive drain at slot count.
+- Unbound transients drop to `rc = 0` and self-destruct, releasing their buffers.
+
+`execStmt` ([`interpreter/interpreterExec.ts`](../../../src/numbl-core/interpreter/interpreterExec.ts)) wraps the statement body in `withScope`. The JIT synthetic-fn runner ([`executors/jsJit/shared.ts`](../../../src/numbl-core/executors/jsJit/shared.ts) `runSyntheticFnAgainstEnv`) wraps the JIT-compiled function call so intermediates created by JIT'd loop bodies are subject to scope drain.
+
+`callUserFunction` ([`interpreter/interpreterFunctions.ts`](../../../src/numbl-core/interpreter/interpreterFunctions.ts)) adopts every output value into the **caller's** scope before running `fnEnv.clearLocals()` — outputs are otherwise held only by the callee's slot binding which is about to be decref'd to 0.
+
+## Walk-throughs
+
+```
+c = 2 + 2;
+```
+
+1. Fresh tensor `T` from `2+2`. Refcounted ctor adopts: `T.rc=1` (scope owns).
+2. `env.set("c", T)`: incref → `T.rc=2`; old `c` undefined, no decref.
+3. End of statement, scope drains: decref → `T.rc=1` (just `env.c`).
+
+```
+b = a;        % a is already in env at rc=1
+```
+
+1. `evalExpr(a)` returns env's value; no adopt (env reads aren't fresh).
+2. `env.set("b", a_val)`: incref → `a_val.rc=2`.
+3. Drain: nothing in scope, nothing changes.
+
+```
+2 + 2;        % unbound expression
+```
+
+1. `T = 2+2` adopted: `T.rc=1`.
+2. `env.set("ans", T)`: incref → `T.rc=2`; old `ans` decref.
+3. Drain: decref → `T.rc=1` (held by `env.ans`).
+
+```
+[~, x] = f();
+```
+
+1. Inside `f()`, outputs are read from `fnEnv`. Before `clearLocals`, each output is adopted into the **caller's** scope: `out_i.rc++`.
+2. `fnEnv.clearLocals()` decrefs each binding: `out_i.rc--`.
+3. Caller's `MultiAssign` binds `x` (incref). The `~` lvalue does nothing.
+4. Caller's drain: every output decref'd. `x`'s tensor lands at `rc=1` (env.x); the `~` tensor lands at `rc=0` and is released.
+
+## Runtime flags
+
+- **`rt.poolReclaim`** (default true) — when on, `RuntimeTensor._destroy` and `RuntimeSparseMatrix._destroy` release `data`/`imag`/`pr`/`pi` buffers to `rt.pool`. The pool poisons released buffers with `NaN`, so any use-after-free shows up loudly in test output rather than as a silent zero-fill match.
+- **`rt.strictRefcount`** (default false) — when on, `decref` on a zero-count throws. Off by default because chained-lvalue assignments (e.g. `T.x(1).y = 10`) currently produce harmless underflows during scope drain. Flipping it on requires a cleanup pass over the back-write chain in `setMemberReturn` / indexed-store callbacks.
+
+## Buffer-sharing constraint
+
+A `Float64Array` buffer can have **only one wrapper owner**. Operations that previously returned a wrapper aliasing the source's buffer (zero-copy `reshape`, `squeeze`) now copy the data. The sweep-based COW system tolerates buffer aliasing during read paths but no construction path should produce two `RuntimeTensor`s pointing at the same `Float64Array`.

--- a/docs/developer_reference/runtime/refcount.md
+++ b/docs/developer_reference/runtime/refcount.md
@@ -2,7 +2,7 @@
 
 The runtime tracks reference counts on every container kind so that `Float64Array` buffers are released back to the per-runtime memory pool when their owning wrapper is no longer reachable. Strict ownership is enforced by an API on the container classes; the surrounding interpreter, JIT, and store paths thread the runtime through so every binding mutation goes through the API.
 
-This system is for **pool reclamation only**. Copy-on-write decisions still go through the sweep in [`runtime/aliasing.ts`](../../../src/numbl-core/runtime/aliasing.ts); refcount being slightly off is a leak or, in `poolReclaim` mode, a premature buffer release — never silent data corruption from missed COW.
+This system is for **buffer reclamation only**. Copy-on-write decisions still go through the sweep in [`runtime/aliasing.ts`](../../../src/numbl-core/runtime/aliasing.ts); refcount being slightly off is a leak or, with `memPool` on, a premature buffer release — never silent data corruption from missed COW.
 
 ## `Refcounted`
 
@@ -11,7 +11,7 @@ Defined in [`runtime/refcount.ts`](../../../src/numbl-core/runtime/refcount.ts).
 - `_rc: number` — starts at 0. A "newborn" wrapper is owned by no slot.
 - `incref()` — bumps `_rc`.
 - `decref(rt)` — decrements; if the count hits 0, runs `_destroy(rt)`.
-- `_destroy(rt)` — kind-specific. Tensors and sparse matrices release their `Float64Array` buffers via `rt.pool.release(...)` (gated by `rt.poolReclaim`). Containers with child refs decref each child.
+- `_destroy(rt)` — kind-specific. Tensors and sparse matrices release their `Float64Array` buffers via `rt.pool.release(...)` (gated by `rt.memPool`). Containers with child refs decref each child.
 
 The free helpers `incref(v)` and `decref(rt, v)` are noops on primitives (`number | boolean | string`).
 
@@ -78,7 +78,7 @@ b = a;        % a is already in env at rc=1
 
 ## Runtime flags
 
-- **`rt.poolReclaim`** (default true) — when on, `RuntimeTensor._destroy` and `RuntimeSparseMatrix._destroy` release `data`/`imag`/`pr`/`pi` buffers to `rt.pool`. The pool poisons released buffers with `NaN`, so any use-after-free shows up loudly in test output rather than as a silent zero-fill match.
+- **`rt.memPool`** (default true) — when on, `RuntimeTensor._destroy` and `RuntimeSparseMatrix._destroy` release `data`/`imag`/`pr`/`pi` buffers to `rt.pool` for reuse. The pool poisons released buffers with `NaN`, so any use-after-free shows up loudly in test output rather than as a silent zero-fill match. Disable with the CLI's `--no-mem-pool` flag (or via the worker's `set_mem_pool` message in the browser IDE) to isolate bugs that may stem from buffer recycling: with the flag off, every allocation is a fresh `new Float64Array` and no buffer is ever released.
 - **`rt.strictRefcount`** (default false) — when on, `decref` on a zero-count throws. Off by default because chained-lvalue assignments (e.g. `T.x(1).y = 10`) currently produce harmless underflows during scope drain. Flipping it on requires a cleanup pass over the back-write chain in `setMemberReturn` / indexed-store callbacks.
 
 ## Buffer-sharing constraint

--- a/docs/developer_reference/runtime/values-and-tensors.md
+++ b/docs/developer_reference/runtime/values-and-tensors.md
@@ -2,11 +2,11 @@
 
 ## `RuntimeValue`
 
-The runtime universe. A discriminated union of all values a numbl program can hold:
+The runtime universe. A union of primitives plus refcounted classes:
 
-- `number` — JavaScript number (real scalar).
-- `boolean` — logical scalar.
-- `string` — MATLAB string (distinct from char).
+- `number` — JavaScript number (real scalar). Not refcounted.
+- `boolean` — logical scalar. Not refcounted.
+- `string` — MATLAB string (distinct from char). Not refcounted.
 - `RuntimeChar` — MATLAB char array.
 - `RuntimeTensor` — real or complex, any rank, any shape.
 - `RuntimeComplexNumber` — complex scalar.
@@ -16,7 +16,9 @@ The runtime universe. A discriminated union of all values a numbl program can ho
 - `RuntimeFunction` / function handle — callable reference.
 - Sparse matrix, dictionary, and a few others.
 
-Type-guard predicates follow the pattern `isRuntimeTensor(v)`, `isRuntimeChar(v)`, etc. Use these instead of examining shape fields directly.
+Every container kind is a class extending `Refcounted` (`runtime/refcount.ts`). Each instance carries a `_rc` field (starts at 0) and `incref()` / `decref(rt)` methods enforced by a strict slot API; see [refcount.md](refcount.md) for the lifecycle.
+
+Type-guard predicates follow the pattern `isRuntimeTensor(v)`, `isRuntimeChar(v)`, etc. — they check `value.kind === "..."` and continue to work on the class instances. Use these instead of examining shape fields directly or using `instanceof`.
 
 ## `RTV` constructors
 
@@ -35,7 +37,9 @@ A `RuntimeTensor` holds:
 
 **Column-major layout.** Element `(i, j)` of an `[m, n]` matrix is at flat index `j * m + i`. All tensor code assumes this; any new operation must preserve it.
 
-**Copy-on-write.** Assigning a tensor variable or passing it as an argument shares the same underlying buffer. Before an indexed store mutates a tensor, the runtime decides whether to clone by running an on-demand reachability sweep from a small set of roots (active env chain, caller-env stack `rt._envStack`, globals, persistents) — see [`runtime/aliasing.ts`](../../../src/numbl-core/runtime/aliasing.ts). The LHS slot is excluded from the sweep, so a tensor that's only reachable through the slot being overwritten is treated as uniquely owned and mutated in place. The sweep also flags buffer-sharing aliases (e.g. zero-copy `reshape` returns a new wrapper whose `data` is the same `Float64Array`). A hard visit budget caps worst-case cost; on exhaustion the sweep returns true (conservative copy). There is no per-tensor refcount or other incremental bookkeeping.
+**Copy-on-write.** Assigning a tensor variable or passing it as an argument shares the same underlying buffer. Before an indexed store mutates a tensor, the runtime decides whether to clone by running an on-demand reachability sweep from a small set of roots (active env chain, caller-env stack `rt._envStack`, globals, persistents) — see [`runtime/aliasing.ts`](../../../src/numbl-core/runtime/aliasing.ts). The LHS slot is excluded from the sweep, so a tensor that's only reachable through the slot being overwritten is treated as uniquely owned and mutated in place. A hard visit budget caps worst-case cost; on exhaustion the sweep returns true (conservative copy). The refcount system runs alongside the sweep but does not drive COW; see [refcount.md](refcount.md).
+
+**No buffer sharing across wrappers.** `reshape` and `squeeze` previously returned a new `RuntimeTensor` whose `data` aliased the source's buffer (zero-copy). With refcount-driven pool reclamation in place, two wrappers cannot co-own one buffer — the second `_destroy` would release an already-pooled buffer. These ops now copy the data instead. Trade: one extra `Float64Array` copy per reshape/squeeze, in exchange for a single owner per buffer.
 
 ## Tensor ops
 

--- a/src/__tests__/coverage-extras2.test.ts
+++ b/src/__tests__/coverage-extras2.test.ts
@@ -13,8 +13,9 @@ import { valuesAreEqual } from "../numbl-core/runtime/compare.js";
 import { RTV } from "../numbl-core/runtime/constructors.js";
 import {
   type RuntimeValue,
-  type RuntimeClassInstance,
-  type RuntimeFunction,
+  RuntimeClassInstance,
+  RuntimeFunction,
+  RuntimeChar,
 } from "../numbl-core/runtime/types.js";
 import { allocFloat64Array } from "../numbl-core/executors/jsJit/helpers/alloc.js";
 
@@ -355,12 +356,7 @@ describe("displayValue", () => {
   });
 
   it("displays function handle", () => {
-    const fn: RuntimeFunction = {
-      kind: "function",
-      name: "sin",
-      captures: [],
-      impl: "builtin",
-    };
+    const fn: RuntimeFunction = new RuntimeFunction("sin", "builtin", []);
     expect(displayValue(fn)).toBe("@sin");
   });
 
@@ -385,12 +381,11 @@ describe("displayValue", () => {
   });
 
   it("displays class instance", () => {
-    const inst: RuntimeClassInstance = {
-      kind: "class_instance",
-      className: "MyClass",
-      fields: new Map([["val", 42]]),
-      isHandleClass: false,
-    };
+    const inst: RuntimeClassInstance = new RuntimeClassInstance(
+      "MyClass",
+      new Map([["val", 42]]),
+      false
+    );
     const s = displayValue(inst);
     expect(s).toContain("MyClass");
     expect(s).toContain("val:");
@@ -405,7 +400,7 @@ describe("displayValue", () => {
   });
 
   it("displays multi-row char array", () => {
-    const c = { kind: "char" as const, value: "abcdef", shape: [2, 3] };
+    const c = new RuntimeChar("abcdef", [2, 3]);
     const s = displayValue(c);
     expect(s).toBe("abc\ndef");
   });

--- a/src/__tests__/memoryPool.test.ts
+++ b/src/__tests__/memoryPool.test.ts
@@ -34,13 +34,42 @@ describe("MemoryPool", () => {
     expect(s.attemptedAllocs).toBe(s.actualAllocs + s.cacheHits);
   });
 
-  it("nothing is released or pooled without explicit release()", () => {
-    const result = executeCode("for k=1:50; x = zeros(100, 1); end");
+  it("refcount-driven reclamation: a discarded transient is released", () => {
+    // The intermediate `zeros(100, 1)` is bound to env.x then immediately
+    // overwritten with a different size, so its 100-length buffer drops
+    // to rc=0 on the second statement and is released to the pool.
+    const result = executeCode(
+      "x = zeros(100, 1); x = zeros(50, 1); clear x;",
+      { optimization: "0" }
+    );
     const s = result.memoryStats!;
-    // No automatic reclamation: every alloc goes through `new Float64Array`.
-    expect(s.cacheHits).toBe(0);
-    expect(s.releases).toBe(0);
-    expect(s.freePoolBufferCount).toBe(0);
+    expect(s.releases).toBeGreaterThan(0);
+    // Eventually the pool's freePool holds buffers for reuse.
+    expect(s.freePoolBufferCount + s.cacheHits).toBeGreaterThan(0);
+  });
+
+  it("refcount-driven reclamation: in a tight loop (interpreter), buffers are reused", () => {
+    // With opt 0 (interpreter), each iteration is its own statement-level
+    // scope. The previous iteration's tensor is decref'd to 0 and pooled
+    // before the next iteration runs, so most allocations should hit the
+    // pool's free buckets.
+    const result = executeCode("for k=1:50; x = zeros(100, 1); end", {
+      optimization: "0",
+    });
+    const s = result.memoryStats!;
+    expect(s.releases).toBeGreaterThanOrEqual(40);
+    expect(s.cacheHits).toBeGreaterThanOrEqual(40);
+  });
+
+  it("refcount-driven reclamation: JIT top-level releases after the synthetic fn returns", () => {
+    // The JIT-compiled top-level wraps the whole script in one scope, so
+    // mid-loop releases don't happen, but at scope drain every dead
+    // wrapper's buffer is reclaimed.
+    const result = executeCode("for k=1:50; x = zeros(100, 1); end", {
+      optimization: "1",
+    });
+    const s = result.memoryStats!;
+    expect(s.releases).toBeGreaterThanOrEqual(40);
   });
 
   it("manual release() puts a buffer in the free pool, next acquire reuses it", () => {

--- a/src/__tests__/runtime-utils.test.ts
+++ b/src/__tests__/runtime-utils.test.ts
@@ -9,6 +9,9 @@ import {
 import { RTV } from "../numbl-core/runtime/constructors.js";
 import { valuesAreEqual } from "../numbl-core/runtime/compare.js";
 import {
+  RuntimeTensor,
+  RuntimeCell,
+  RuntimeComplexNumber,
   isRuntimeNumber,
   isRuntimeLogical,
   isRuntimeString,
@@ -82,29 +85,17 @@ describe("sub2ind", () => {
 
 describe("tensorSize2D", () => {
   it("returns [1,1] for empty shape", () => {
-    const t = {
-      kind: "tensor" as const,
-      data: allocFloat64Array(1),
-      shape: [],
-    };
+    const t = new RuntimeTensor(allocFloat64Array(1), []);
     expect(tensorSize2D(t)).toEqual([1, 1]);
   });
 
   it("returns [1,n] for 1D shape", () => {
-    const t = {
-      kind: "tensor" as const,
-      data: allocFloat64Array(3),
-      shape: [3],
-    };
+    const t = new RuntimeTensor(allocFloat64Array(3), [3]);
     expect(tensorSize2D(t)).toEqual([1, 3]);
   });
 
   it("returns shape for 2D", () => {
-    const t = {
-      kind: "tensor" as const,
-      data: allocFloat64Array(6),
-      shape: [2, 3],
-    };
+    const t = new RuntimeTensor(allocFloat64Array(6), [2, 3]);
     expect(tensorSize2D(t)).toEqual([2, 3]);
   });
 });
@@ -136,7 +127,7 @@ describe("type guards", () => {
   });
 
   it("isRuntimeCell", () => {
-    const c = { kind: "cell" as const, data: [1, "hi"], shape: [1, 2] };
+    const c = new RuntimeCell([1, "hi"], [1, 2]);
     expect(isRuntimeCell(c)).toBe(true);
     expect(isRuntimeCell(42)).toBe(false);
   });
@@ -172,9 +163,9 @@ describe("valuesAreEqual", () => {
   });
 
   it("compares complex numbers", () => {
-    const a = { kind: "complex_number" as const, re: 1, im: 2 };
-    const b = { kind: "complex_number" as const, re: 1, im: 2 };
-    const c = { kind: "complex_number" as const, re: 1, im: 3 };
+    const a = new RuntimeComplexNumber(1, 2);
+    const b = new RuntimeComplexNumber(1, 2);
+    const c = new RuntimeComplexNumber(1, 3);
     expect(valuesAreEqual(a, b)).toBe(true);
     expect(valuesAreEqual(a, c)).toBe(false);
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -226,7 +226,8 @@ function findTestFiles(dir: string): string[] {
 async function runTests(
   dir: string,
   optimization?: import("./numbl-core/executors/plugins.js").OptLevel,
-  fastMath?: boolean
+  fastMath?: boolean,
+  memPool?: boolean
 ) {
   loadNativeAddon(fastMath ?? true);
   const absDir = resolve(process.cwd(), dir);
@@ -256,6 +257,7 @@ async function runTests(
           displayResults: true,
           optimization: optimization ?? 1,
           fastMath,
+          memPool,
           fileIO: new NodeFileIOAdapter(),
           system: new NodeSystemAdapter(),
         },
@@ -348,6 +350,12 @@ Options (for run and eval):
                      (default is on: libmvec-vectorized transcendentals,
                      reductions reorder-allowed; opt out for
                      bitwise-deterministic FP semantics)
+  --no-mem-pool      Disable buffer reuse from the per-runtime memory pool
+                     (default is on: refcounted Float64Array buffers are
+                     released to the pool and reused on next allocation;
+                     opt out to make every allocation a fresh
+                     new Float64Array, isolating bugs that may stem from
+                     buffer recycling)
 
 Environment variables:
   NUMBL_PATH              Extra workspace directories (separated by ${delimiter})`);
@@ -368,6 +376,7 @@ interface ParsedOptions {
   profileOutput: string | undefined;
   optimization: import("./numbl-core/executors/plugins.js").OptLevel;
   fastMath: boolean;
+  memPool: boolean;
 }
 
 function parseOptions(args: string[]): ParsedOptions {
@@ -384,6 +393,7 @@ function parseOptions(args: string[]): ParsedOptions {
     profileOutput: undefined,
     optimization: "1",
     fastMath: true,
+    memPool: true,
   };
 
   // Seed extraPaths from NUMBL_PATH environment variable (platform path separator)
@@ -421,6 +431,9 @@ function parseOptions(args: string[]): ParsedOptions {
         break;
       case "--no-fast-math":
         opts.fastMath = false;
+        break;
+      case "--no-mem-pool":
+        opts.memPool = false;
         break;
       case "--dump-ast":
         opts.dumpAst = true;
@@ -696,6 +709,7 @@ async function executeWithOptions(
 
             optimization: opts.optimization,
             fastMath: opts.fastMath,
+            memPool: opts.memPool,
           },
           workspaceFiles,
           mainFileName,
@@ -755,6 +769,7 @@ async function executeWithOptions(
           onInput,
           optimization: opts.optimization,
           fastMath: opts.fastMath,
+          memPool: opts.memPool,
         },
         workspaceFiles,
         mainFileName,
@@ -794,6 +809,7 @@ async function executeWithOptions(
           onInput,
           optimization: opts.optimization,
           fastMath: opts.fastMath,
+          memPool: opts.memPool,
         },
         workspaceFiles,
         mainFileName,
@@ -1242,7 +1258,12 @@ async function main() {
         testOpts.positional.length > 0
           ? testOpts.positional[0]
           : join(packageDir, "numbl_test_scripts");
-      await runTests(dir, testOpts.optimization, testOpts.fastMath);
+      await runTests(
+        dir,
+        testOpts.optimization,
+        testOpts.fastMath,
+        testOpts.memPool
+      );
       break;
     }
     case "build-addon":

--- a/src/components/IDEWorkspace.tsx
+++ b/src/components/IDEWorkspace.tsx
@@ -222,6 +222,7 @@ export function IDEWorkspace({
   );
   const [optimization, setOptimization] =
     useState<import("../numbl-core/executors/plugins.js").OptLevel>("1");
+  const [memPool, setMemPool] = useState(true);
   const [output, setOutput] = useState("");
   const [dispatchUnknownCounts, setDispatchUnknownCounts] = useState<Record<
     string,
@@ -361,6 +362,14 @@ export function IDEWorkspace({
       optimization,
     });
   }, [optimization]);
+
+  // Sync memPool flag to worker when toggled
+  useEffect(() => {
+    workerRef.current?.postMessage({
+      type: "set_mem_pool",
+      memPool,
+    });
+  }, [memPool]);
 
   // Panel sizing
   const initialSidebarWidth = window.innerWidth >= 1200 ? 260 : 200;
@@ -1125,6 +1134,31 @@ export function IDEWorkspace({
                   }}
                 >
                   {optimization === "0" ? "no jit" : "jit"}
+                </Typography>
+              </Tooltip>
+              <Tooltip
+                title={
+                  memPool
+                    ? "Memory pool on (refcounted Float64Array buffers reused; click to disable for debugging)"
+                    : "Memory pool off (every alloc is a fresh new Float64Array; click to re-enable)"
+                }
+              >
+                <Typography
+                  variant="caption"
+                  onClick={() => setMemPool(p => !p)}
+                  sx={{
+                    cursor: "pointer",
+                    fontSize: "0.7rem",
+                    px: 0.5,
+                    py: 0.1,
+                    borderRadius: 0.5,
+                    bgcolor: memPool ? "action.selected" : "transparent",
+                    opacity: memPool ? 1 : 0.5,
+                    "&:hover": { opacity: 1 },
+                    userSelect: "none",
+                  }}
+                >
+                  {memPool ? "mem pool" : "no mem pool"}
                 </Typography>
               </Tooltip>
               {activeFile && (

--- a/src/hooks/fetchMipCoreFiles.ts
+++ b/src/hooks/fetchMipCoreFiles.ts
@@ -6,10 +6,17 @@ const MIP_SYSTEM_PREFIX = "mip/packages/gh/mip-org/core/mip/";
 
 function proxiedUrl(url: string): string {
   if (/^https:\/\/github\.com\/.+\/releases\/download\/.+/.test(url)) {
-    return url.replace(
+    let proxied = url.replace(
       "https://github.com/",
       "https://mip-cors-proxy.figurl.workers.dev/gh/"
     );
+    // Cachebust applies only when going through the proxy: the
+    // mip-numbl release tag is mutable so the same URL keeps serving
+    // whatever was last published, and otherwise the browser / proxy
+    // happily return a stale .mhl for hours.
+    proxied += proxied.includes("?") ? "&" : "?";
+    proxied += "t=" + Date.now();
+    return proxied;
   }
   return url;
 }
@@ -21,7 +28,9 @@ export interface VfsFile {
 
 /**
  * Fetches the mip core package from GitHub, unzips it, and returns
- * VFS-ready files with /system/ prefix paths.
+ * VFS-ready files with /system/ prefix paths. The URL goes through
+ * `proxiedUrl`, which appends a per-call `?t=<ms>` cachebust when (and
+ * only when) it rewrites a GitHub-release URL onto the CORS proxy.
  */
 export async function fetchMipCoreFiles(): Promise<VfsFile[]> {
   const resp = await fetch(proxiedUrl(MHL_URL));

--- a/src/numbl-core/executeCode.ts
+++ b/src/numbl-core/executeCode.ts
@@ -76,6 +76,13 @@ export interface ExecOptions {
    *  transcendentals; reductions are reorder-allowed). Default true;
    *  opt out via the CLI's `--no-fast-math` flag. */
   fastMath?: boolean;
+  /** Reclaim Float64Array buffers back to the per-runtime pool when
+   *  the owning wrapper's refcount hits zero. Default true; opt out
+   *  via the CLI's `--no-mem-pool` flag (or the worker's
+   *  `set_mem_pool` message) to isolate bugs that may be caused by
+   *  buffer recycling. With the flag off, every allocation is a
+   *  fresh `new Float64Array` and no buffer is ever released. */
+  memPool?: boolean;
   /**
    * Initial implicit cwd path for the MATLAB-style "cwd is the first search path" feature.
    * - undefined → auto-detect from `system.cwd()` and scan its files.
@@ -335,6 +342,7 @@ export function executeCode(
   }
 
   const rt = new Runtime(options, options.initialVariableValues);
+  rt.memPool = options.memPool ?? true;
 
   // Build the per-runtime jitHelpers ($h) snapshot. This must happen AFTER
   // Runtime construction so it captures the special-builtin closures bound

--- a/src/numbl-core/executors/cJit/chainExecutor.ts
+++ b/src/numbl-core/executors/cJit/chainExecutor.ts
@@ -18,7 +18,7 @@
 import type { Executor, Proposal, RunResult } from "../types.js";
 import type { DispatchContext } from "../context.js";
 import type { LoweredStmt, SynthLoweredStmt } from "../lowering.js";
-import type { RuntimeTensor, RuntimeValue } from "../../runtime/types.js";
+import { RuntimeTensor, type RuntimeValue } from "../../runtime/types.js";
 import type { ChainAnalysis } from "./chainPass.js";
 import {
   buildChainDeclaration,
@@ -245,12 +245,7 @@ export const cJitChainExecutor: Executor<
     // Wrap each live-out as a RuntimeTensor with the matching shape.
     for (let k = 0; k < res.liveOuts.length; k++) {
       const name = res.liveOuts[k];
-      const result: RuntimeTensor = {
-        kind: "tensor",
-        data: outs[k],
-        imag: undefined,
-        shape: [...templateShape],
-      };
+      const result = new RuntimeTensor(outs[k], [...templateShape]);
       interp.env.set(name, result as RuntimeValue);
     }
     return { ok: true };

--- a/src/numbl-core/executors/cJit/fuseExecutor.ts
+++ b/src/numbl-core/executors/cJit/fuseExecutor.ts
@@ -19,7 +19,7 @@
 import type { Executor, Proposal, RunResult } from "../types.js";
 import type { DispatchContext } from "../context.js";
 import type { LoweredStmt, FuseLoweredStmt } from "../lowering.js";
-import type { RuntimeTensor, RuntimeValue } from "../../runtime/types.js";
+import { RuntimeTensor, type RuntimeValue } from "../../runtime/types.js";
 import { generateFuseCSource } from "./fuseCodegen.js";
 import { compileAndLoad, type CompiledC } from "./compile.js";
 import { allocFloat64Array } from "../jsJit/helpers/alloc.js";
@@ -217,12 +217,7 @@ export const cJitFuseExecutor: Executor<FuseLoweredStmt, CFuseCompiled | null> =
       }
 
       // Wrap as RuntimeTensor preserving the input's shape.
-      const result: RuntimeTensor = {
-        kind: "tensor",
-        data: out,
-        imag: undefined,
-        shape: [...templateShape],
-      };
+      const result = new RuntimeTensor(out, [...templateShape]);
       interp.env.set(d.classification.outputName, result as RuntimeValue);
       return { ok: true };
     },

--- a/src/numbl-core/executors/jsJit/helpers/alloc.ts
+++ b/src/numbl-core/executors/jsJit/helpers/alloc.ts
@@ -14,9 +14,33 @@ import { getCurrentRuntime } from "../../../runtime/memoryPool.js";
  *
  *  When no runtime is active (e.g. unit tests of pure helpers), this
  *  also falls back to a plain `new Float64Array`. */
+/** Allocations of <= 100 doubles bypass the pool unconditionally — the
+ *  per-acquire bookkeeping (liveSet membership + counter increments)
+ *  costs more than the alloc itself, and small buffers in the free
+ *  list rarely help (most reuse opportunities come from larger
+ *  intermediate tensors). Tune the threshold here if profiling shows
+ *  small allocations dominating. */
+const SMALL_ALLOC_THRESHOLD = 100;
+
+/** When running under vitest, route every allocation through the pool
+ *  regardless of size so the test suite exercises pool semantics for
+ *  buffers of every shape. Vitest sets `process.env.VITEST = "true"`. */
+const IN_TEST =
+  typeof process !== "undefined" && process.env?.VITEST === "true";
+
 export function allocFloat64Array(
   x: number | number[] | Float64Array
 ): Float64Array {
+  // Fast path for small allocations: plain `new Float64Array` regardless
+  // of whether a runtime is active or memPool is on. Skipped under
+  // vitest so pool semantics get exercised at every size.
+  if (!IN_TEST) {
+    if (typeof x === "number") {
+      if (x <= SMALL_ALLOC_THRESHOLD) return new Float64Array(x);
+    } else if (x.length <= SMALL_ALLOC_THRESHOLD) {
+      return new Float64Array(x);
+    }
+  }
   const rt = getCurrentRuntime();
   if (!rt || !rt.memPool) {
     if (typeof x === "number") return new Float64Array(x);

--- a/src/numbl-core/executors/jsJit/helpers/alloc.ts
+++ b/src/numbl-core/executors/jsJit/helpers/alloc.ts
@@ -1,19 +1,24 @@
 import { getCurrentRuntime } from "../../../runtime/memoryPool.js";
 
 /** Allocate a Float64Array. When a Runtime is active on the module-level
- *  stack, allocations are routed through that runtime's MemoryPool so
- *  alloc counters and the IDE Memory tab can report on them. The pool
- *  also has a free-list mechanism (`acquire` checks before allocating
- *  fresh, `release` returns a buffer to it) but nothing currently calls
- *  `release` — reclamation strategy is deferred.
+ *  stack and `rt.memPool` is on, allocations are routed through that
+ *  runtime's MemoryPool — `acquire` may return a buffer from the free
+ *  list (filled by `release` on refcount-zero `_destroy`) and counters
+ *  feed the IDE Memory tab.
+ *
+ *  When `rt.memPool` is off (CLI `--no-mem-pool`, IDE toggle), the
+ *  pool is bypassed completely: every allocation is a fresh
+ *  `new Float64Array` with no tracking, no free-list lookup, no
+ *  liveSet bookkeeping. This is the fastest possible path and is
+ *  intended for isolating bugs that may stem from buffer recycling.
  *
  *  When no runtime is active (e.g. unit tests of pure helpers), this
- *  falls back to a plain `new Float64Array` with no tracking. */
+ *  also falls back to a plain `new Float64Array`. */
 export function allocFloat64Array(
   x: number | number[] | Float64Array
 ): Float64Array {
   const rt = getCurrentRuntime();
-  if (!rt) {
+  if (!rt || !rt.memPool) {
     if (typeof x === "number") return new Float64Array(x);
     return new Float64Array(x);
   }

--- a/src/numbl-core/executors/jsJit/helpers/jitHelpers.ts
+++ b/src/numbl-core/executors/jsJit/helpers/jitHelpers.ts
@@ -14,7 +14,7 @@
 import {
   type RuntimeTensor,
   type RuntimeFunction,
-  type RuntimeStruct,
+  RuntimeStruct,
   type RuntimeValue,
 } from "../../../runtime/types.js";
 
@@ -503,10 +503,7 @@ export const jitHelpers = {
   // Used by AssignMember codegen to (re)initialize a variable as a
   // fresh empty struct (for the MATLAB `s = []; s.f = v` idiom or a
   // write-only local) and to set a field on an existing struct.
-  structNew_h: (): RuntimeStruct => ({
-    kind: "struct",
-    fields: new Map(),
-  }),
+  structNew_h: (): RuntimeStruct => new RuntimeStruct(new Map()),
   structSetField_h: (
     s: RuntimeStruct,
     field: string,

--- a/src/numbl-core/executors/jsJit/helpers/jitHelpersComplex.ts
+++ b/src/numbl-core/executors/jsJit/helpers/jitHelpersComplex.ts
@@ -3,7 +3,7 @@
  * These are pure functions used by the $h helpers object.
  */
 
-import type { RuntimeComplexNumber } from "../../../runtime/types.js";
+import { RuntimeComplexNumber } from "../../../runtime/types.js";
 
 export function re(v: unknown): number {
   if (typeof v === "number") return v;
@@ -17,7 +17,7 @@ export function im(v: unknown): number {
 
 export function mkc(r: number, i: number): number | RuntimeComplexNumber {
   if (i === 0) return r;
-  return { kind: "complex_number", re: r, im: i };
+  return new RuntimeComplexNumber(r, i);
 }
 
 export function cAdd(a: unknown, b: unknown): number | RuntimeComplexNumber {

--- a/src/numbl-core/executors/jsJit/helpers/jitHelpersTensor.ts
+++ b/src/numbl-core/executors/jsJit/helpers/jitHelpersTensor.ts
@@ -4,7 +4,7 @@
  * tensor coercion for struct-array field access.
  */
 
-import { type RuntimeTensor } from "../../../runtime/types.js";
+import { RuntimeTensor } from "../../../runtime/types.js";
 import type { RuntimeComplexNumber } from "../../../runtime/types.js";
 import { re, im, mkc, cAdd, cSub, cMul, cDiv } from "./jitHelpersComplex.js";
 import { tensorOps, OpRealBin } from "../../../ops/index.js";
@@ -39,13 +39,7 @@ export function makeTensor(
 ): RuntimeTensor {
   const s = [...shape];
   while (s.length > 2 && s[s.length - 1] === 1) s.pop();
-  const t: RuntimeTensor = {
-    kind: "tensor",
-    data,
-    shape: s,
-  };
-  if (imag) t.imag = imag;
-  return t;
+  return new RuntimeTensor(data, s, imag);
 }
 
 // ── Output-buffer reuse (dest-hint) ────────────────────────────────────
@@ -465,14 +459,12 @@ export function unshare(t: unknown): RuntimeTensor {
     newImag = allocFloat64Array(tt.imag.length);
     newImag.set(tt.imag);
   }
-  const copy: RuntimeTensor = {
-    kind: "tensor",
-    data: newData,
-    shape: tt.shape.slice(),
-  };
-  if (newImag) copy.imag = newImag;
-  if (tt._isLogical) copy._isLogical = tt._isLogical;
-  return copy;
+  return new RuntimeTensor(
+    newData,
+    tt.shape.slice(),
+    newImag,
+    tt._isLogical || undefined
+  );
 }
 
 // ── Scalar → 1x1 tensor coercion ──────────────────────────────────────

--- a/src/numbl-core/executors/jsJit/shared.ts
+++ b/src/numbl-core/executors/jsJit/shared.ts
@@ -291,20 +291,30 @@ export function runSyntheticFnAgainstEnv(
 ): SyntheticFnRunResult {
   const inputValues = gatherEnvValues(interp, inputs);
 
-  let result: unknown;
-  try {
-    result = fn(...inputValues);
-  } catch (e) {
-    if (e instanceof JitFuncHandleBailError) {
-      console.warn(`Warning: ${e.message}`);
-      return { ok: false, transient: false };
+  // Establish a transient scope around the synthetic fn call. Tensors
+  // built inside the JIT-compiled body auto-adopt into this scope on
+  // construction; intermediate values that get overwritten in JS-local
+  // vars (e.g. the loop body's `x = zeros(...)` rebinding each iter)
+  // are decref'd when the scope drains, releasing their buffers to the
+  // pool. The scope also wraps writeBackOutputs so the returned values
+  // get bound to env BEFORE the scope drains — keeping their slot
+  // refcount intact.
+  return interp.rt.withScope(() => {
+    let result: unknown;
+    try {
+      result = fn(...inputValues);
+    } catch (e) {
+      if (e instanceof JitFuncHandleBailError) {
+        console.warn(`Warning: ${e.message}`);
+        return { ok: false, transient: false };
+      }
+      if (e instanceof JitBailToInterpreter) {
+        return { ok: false, transient: true };
+      }
+      throw e;
     }
-    if (e instanceof JitBailToInterpreter) {
-      return { ok: false, transient: true };
-    }
-    throw e;
-  }
 
-  writeBackOutputs(interp, outputs, result);
-  return { ok: true };
+    writeBackOutputs(interp, outputs, result);
+    return { ok: true };
+  });
 }

--- a/src/numbl-core/helpers/arithmetic.ts
+++ b/src/numbl-core/helpers/arithmetic.ts
@@ -1384,11 +1384,7 @@ function asNumeric(
     );
     return {
       scalar: false,
-      tensor: {
-        kind: "tensor",
-        data: codes,
-        shape: [1, v.value.length],
-      },
+      tensor: RTV.tensorRaw(codes, [1, v.value.length]),
     };
   }
   throw new RuntimeError(`Cannot use ${kstr(v)} in numeric operation`);

--- a/src/numbl-core/helpers/reduction/min-max.ts
+++ b/src/numbl-core/helpers/reduction/min-max.ts
@@ -399,7 +399,11 @@ export function minMaxImpl(
         name,
         [
           isRuntimeTensor(v)
-            ? RTV.tensor(v.data, [1, v.data.length], v.imag)
+            ? RTV.tensor(
+                allocFloat64Array(v.data),
+                [1, v.data.length],
+                v.imag ? allocFloat64Array(v.imag) : undefined
+              )
             : v,
         ],
         nargout,

--- a/src/numbl-core/helpers/sparse-arithmetic.ts
+++ b/src/numbl-core/helpers/sparse-arithmetic.ts
@@ -57,7 +57,7 @@ function sparseToDense(S: RuntimeSparseMatrix): RuntimeTensor {
       if (imag && S.pi) imag[idx] = S.pi[k];
     }
   }
-  return { kind: "tensor", data, imag, shape: [S.m, S.n] };
+  return RTV.tensor(data, [S.m, S.n], imag);
 }
 
 /** Get scalar value (real) from a RuntimeValue, or NaN if not scalar. */

--- a/src/numbl-core/interpreter/builtins/array-manipulation.ts
+++ b/src/numbl-core/interpreter/builtins/array-manipulation.ts
@@ -594,10 +594,7 @@ defineBuiltin({
         const v = args[0];
         if (isRuntimeNumber(v)) return v;
         if (isRuntimeChar(v))
-          return {
-            kind: "char",
-            value: v.value.split("").reverse().join(""),
-          };
+          return RTV.char(v.value.split("").reverse().join(""));
         if (isRuntimeSparseMatrix(v)) return flipSparse(v, 1);
         if (!isRuntimeTensor(v))
           throw new RuntimeError("fliplr: argument must be numeric or char");

--- a/src/numbl-core/interpreter/builtins/array-manipulation.ts
+++ b/src/numbl-core/interpreter/builtins/array-manipulation.ts
@@ -16,7 +16,7 @@ import {
   vertcat,
 } from "../../runtime/index.js";
 import {
-  type RuntimeTensor,
+  RuntimeTensor,
   type RuntimeValue,
   isRuntimeNumber,
   isRuntimeLogical,
@@ -257,15 +257,17 @@ defineBuiltin({
           throw new RuntimeError("reshape: number of elements must not change");
         }
         if (isRuntimeTensor(v)) {
+          // Copy the data buffer rather than share it. Sharing buffers
+          // across wrappers would require ref-tracking the buffer
+          // itself (multiple wrappers can be alive at once), and the
+          // current refcount design ties buffer lifetime to a single
+          // wrapper. The cost is one extra Float64Array copy on
+          // reshape, traded for simpler refcount semantics.
+          const dataCopy = allocFloat64Array(data);
+          const imagCopy = imag ? allocFloat64Array(imag) : undefined;
           const s = [...shape];
           while (s.length > 2 && s[s.length - 1] === 1) s.pop();
-          return {
-            kind: "tensor",
-            data,
-            imag,
-            shape: s,
-            _isLogical: v._isLogical,
-          } as RuntimeTensor;
+          return new RuntimeTensor(dataCopy, s, imagCopy, v._isLogical);
         }
         return RTV.tensor(
           allocFloat64Array(data),
@@ -978,8 +980,13 @@ defineBuiltin({
           ) {
             effectiveShape.pop();
           }
+          // Copy buffers — sharing them across wrappers conflicts with
+          // refcount-driven pool reclamation (see reshape for the same
+          // tradeoff).
+          const dataCopy = allocFloat64Array(v.data);
+          const imagCopy = v.imag ? allocFloat64Array(v.imag) : undefined;
           if (effectiveShape.length <= 2) {
-            return RTV.tensor(v.data, effectiveShape, v.imag);
+            return RTV.tensor(dataCopy, effectiveShape, imagCopy);
           }
           const newShape = effectiveShape.filter(d => d !== 1);
           if (newShape.length === 0) {
@@ -988,9 +995,9 @@ defineBuiltin({
             return RTV.num(v.data[0]);
           }
           if (newShape.length === 1) {
-            return RTV.tensor(v.data, [newShape[0], 1], v.imag);
+            return RTV.tensor(dataCopy, [newShape[0], 1], imagCopy);
           }
-          return RTV.tensor(v.data, newShape, v.imag);
+          return RTV.tensor(dataCopy, newShape, imagCopy);
         }
         throw new RuntimeError("squeeze: argument must be numeric");
       },

--- a/src/numbl-core/interpreter/builtins/datetime.ts
+++ b/src/numbl-core/interpreter/builtins/datetime.ts
@@ -28,11 +28,9 @@
  * number as a duration.
  */
 
-import type {
-  RuntimeValue,
-  RuntimeClassInstance,
-} from "../../runtime/types.js";
+import type { RuntimeValue } from "../../runtime/types.js";
 import {
+  RuntimeClassInstance,
   isRuntimeChar,
   isRuntimeClassInstance,
   isRuntimeString,
@@ -62,12 +60,7 @@ export function makeDatetime(
     ["Minute", RTV.num(minute)],
     ["Second", RTV.num(second)],
   ]);
-  return {
-    kind: "class_instance",
-    className: "datetime",
-    fields,
-    isHandleClass: false,
-  };
+  return new RuntimeClassInstance("datetime", fields, false);
 }
 
 function datetimeFromDate(d: Date): RuntimeClassInstance {
@@ -108,12 +101,7 @@ export function makeDuration(totalSeconds: number): RuntimeClassInstance {
   const fields = new Map<string, RuntimeValue>([
     ["Seconds", RTV.num(totalSeconds)],
   ]);
-  return {
-    kind: "class_instance",
-    className: "duration",
-    fields,
-    isHandleClass: false,
-  };
+  return new RuntimeClassInstance("duration", fields, false);
 }
 
 function durationSeconds(v: RuntimeClassInstance): number {

--- a/src/numbl-core/interpreter/builtins/introspection.ts
+++ b/src/numbl-core/interpreter/builtins/introspection.ts
@@ -502,7 +502,7 @@ defineBuiltin({
 
 /** Helper to create a RuntimeChar value. */
 function mkChar(value: string): RuntimeChar {
-  return { kind: "char", value };
+  return RTV.char(value);
 }
 
 defineBuiltin({

--- a/src/numbl-core/interpreter/builtins/misc.ts
+++ b/src/numbl-core/interpreter/builtins/misc.ts
@@ -896,7 +896,7 @@ function convertJsonArray(arr: unknown[]): RuntimeValue {
         for (const [key, value] of Object.entries(o)) {
           fields.set(makeValidFieldName(key), convertJsonValue(value));
         }
-        return { kind: "struct" as const, fields };
+        return RTV.struct(fields);
       });
       return RTV.structArray(fieldNames, elements);
     }

--- a/src/numbl-core/interpreter/builtins/set-operations.ts
+++ b/src/numbl-core/interpreter/builtins/set-operations.ts
@@ -929,11 +929,7 @@ function uniqueCellOfStrings(
   const resultData = order.map(i => v.data[i]);
   const isRow = v.shape[0] === 1;
   const resultShape = isRow ? [1, order.length] : [order.length, 1];
-  const result: RuntimeValue = {
-    kind: "cell",
-    data: resultData,
-    shape: resultShape,
-  };
+  const result: RuntimeValue = RTV.cell(resultData, resultShape);
   if (nargout <= 1) return result;
   const ia = RTV.tensor(
     allocFloat64Array(order.map(i => i + 1)),

--- a/src/numbl-core/interpreter/builtins/strings.ts
+++ b/src/numbl-core/interpreter/builtins/strings.ts
@@ -7,6 +7,8 @@
 
 import type { RuntimeValue } from "../../runtime/types.js";
 import {
+  RuntimeTensor,
+  RuntimeChar,
   isRuntimeChar,
   isRuntimeCell,
   isRuntimeLogical,
@@ -458,12 +460,7 @@ function strcmpApply(
       result[i] =
         isText(ai) && isText(bi) && cmp(toString(ai), toString(bi)) ? 1 : 0;
     }
-    return {
-      kind: "tensor",
-      data: result,
-      shape: cellA.shape.slice(),
-      _isLogical: true,
-    };
+    return new RuntimeTensor(result, cellA.shape.slice(), undefined, true);
   }
 
   // One cell, one scalar
@@ -479,12 +476,7 @@ function strcmpApply(
     result[i] =
       isText(s1) && isText(s2) && cmp(toString(s1), toString(s2)) ? 1 : 0;
   }
-  return {
-    kind: "tensor",
-    data: result,
-    shape: cell.shape.slice(),
-    _isLogical: true,
-  };
+  return new RuntimeTensor(result, cell.shape.slice(), undefined, true);
 }
 
 registerIBuiltin({
@@ -606,12 +598,7 @@ function logicalRowFromString(
   const cps = stringCodePoints(s);
   const data = allocFloat64Array(cps.length);
   for (let i = 0; i < cps.length; i++) data[i] = pred(cps[i]) ? 1 : 0;
-  return {
-    kind: "tensor",
-    data,
-    shape: shape ?? [1, cps.length],
-    _isLogical: true,
-  };
+  return new RuntimeTensor(data, shape ?? [1, cps.length], undefined, true);
 }
 
 /** Build a logical tensor by applying a predicate to each element of a numeric tensor. */
@@ -624,12 +611,7 @@ function logicalFromNumericTensor(
   for (let i = 0; i < data.length; i++) {
     out[i] = pred(Math.round(data[i])) ? 1 : 0;
   }
-  return {
-    kind: "tensor",
-    data: out,
-    shape: [...shape],
-    _isLogical: true,
-  };
+  return new RuntimeTensor(out, [...shape], undefined, true);
 }
 
 function isstrpropApply(args: RuntimeValue[]): RuntimeValue {
@@ -680,12 +662,7 @@ function isstrpropApply(args: RuntimeValue[]): RuntimeValue {
     const cp = Math.round(toNumber(v));
     const data = allocFloat64Array(1);
     data[0] = pred(cp) ? 1 : 0;
-    result = {
-      kind: "tensor",
-      data,
-      shape: [1, 1],
-      _isLogical: true,
-    };
+    result = new RuntimeTensor(data, [1, 1], undefined, true);
   } else {
     throw new RuntimeError("isstrprop: unsupported input type");
   }
@@ -1190,11 +1167,7 @@ registerIBuiltin({
           if (nRows === 1) return RTV.char(rowStrs[0]);
           const rowWidth = rowStrs[0].length;
           const paddedRows = rowStrs.map(r => r.padEnd(rowWidth));
-          return {
-            kind: "char" as const,
-            value: paddedRows.join(""),
-            shape: [nRows, rowWidth],
-          };
+          return new RuntimeChar(paddedRows.join(""), [nRows, rowWidth]);
         }
         return RTV.char(String(toNumber(v)));
       },

--- a/src/numbl-core/interpreter/builtins/types.ts
+++ b/src/numbl-core/interpreter/builtins/types.ts
@@ -2,12 +2,10 @@
  * IBuiltin interface, registry, and shared helpers for interpreter builtins.
  */
 
-import type {
-  RuntimeValue,
+import type { RuntimeValue } from "../../runtime/types.js";
+import {
   RuntimeTensor,
   RuntimeComplexNumber,
-} from "../../runtime/types.js";
-import {
   isRuntimeChar,
   isRuntimeClassInstance,
   isRuntimeComplexNumber,
@@ -357,7 +355,7 @@ export function buildIBuiltinHelpers(): Record<
 
 export function mkc(re: number, im: number): number | RuntimeComplexNumber {
   if (im === 0) return re;
-  return { kind: "complex_number", re, im };
+  return new RuntimeComplexNumber(re, im);
 }
 
 export function makeTensor(
@@ -368,13 +366,7 @@ export function makeTensor(
   // Strip trailing singleton dimensions (always keep minimum 2D)
   const s = [...shape];
   while (s.length > 2 && s[s.length - 1] === 1) s.pop();
-  const t: RuntimeTensor = {
-    kind: "tensor",
-    data,
-    shape: s,
-  };
-  if (imag) t.imag = imag;
-  return t;
+  return new RuntimeTensor(data, s, imag);
 }
 
 // ── Type rule helpers ───────────────────────────────────────────────────

--- a/src/numbl-core/interpreter/builtins/utility.ts
+++ b/src/numbl-core/interpreter/builtins/utility.ts
@@ -38,7 +38,7 @@ function sparseToDense(S: RuntimeSparseMatrix): RuntimeTensor {
       if (imag && S.pi) imag[idx] = S.pi[k];
     }
   }
-  return { kind: "tensor", data, imag, shape: [S.m, S.n] };
+  return RTV.tensor(data, [S.m, S.n], imag);
 }
 
 function valuesEqualSimple(a: RuntimeValue, b: RuntimeValue): boolean {

--- a/src/numbl-core/interpreter/builtins/validation.ts
+++ b/src/numbl-core/interpreter/builtins/validation.ts
@@ -263,7 +263,7 @@ function matchesOneClass(v: RuntimeValue, cls: string): boolean {
 function getShapeOf(v: RuntimeValue): number[] {
   if (typeof v === "number" || typeof v === "boolean" || typeof v === "string")
     return [1, 1];
-  const obj = v as Record<string, unknown>;
+  const obj = v as unknown as Record<string, unknown>;
   switch (obj.kind) {
     case "tensor":
       return ((obj.shape as number[]) ?? []).length === 0

--- a/src/numbl-core/interpreter/interpreterExec.ts
+++ b/src/numbl-core/interpreter/interpreterExec.ts
@@ -49,6 +49,10 @@ import { allocFloat64Array } from "../executors/jsJit/helpers/alloc.js";
 // ── Statement execution ──────────────────────────────────────────────────
 
 export function execStmt(this: Interpreter, stmt: Stmt): ControlSignal | null {
+  return this.rt.withScope(() => execStmtInner.call(this, stmt));
+}
+
+function execStmtInner(this: Interpreter, stmt: Stmt): ControlSignal | null {
   if (stmt.span) {
     this.rt.$file = stmt.span.file;
     // Compute line number from character offset using cached line table

--- a/src/numbl-core/interpreter/interpreterFunctions.ts
+++ b/src/numbl-core/interpreter/interpreterFunctions.ts
@@ -626,6 +626,20 @@ export function callUserFunction(
       }
     }
 
+    // Adopt every output into the CALLER's transient scope. After
+    // clearLocals decrefs the fnEnv binding the output is held only by
+    // the caller's scope (rc=1) — surviving this function's exit and
+    // available for the caller to bind. If the caller doesn't bind it,
+    // the caller's scope drain releases it normally.
+    //
+    // savedEnv was the caller's env when we entered; rt.currentScope at
+    // this moment is whatever scope the caller's execStmt established
+    // (callUserFunction itself doesn't push a scope — it just executes
+    // the callee statements, each of which manages its own scope).
+    if (this.rt.currentScope) {
+      for (const v of outputs) this.rt.currentScope.adopt(v);
+    }
+
     // Drop locals after collecting outputs. Skip when a `@nestedFn`
     // handle was created during this function's execution: that handle's
     // closure references `fnEnv`, and clearing its vars would strand the

--- a/src/numbl-core/interpreter/types.ts
+++ b/src/numbl-core/interpreter/types.ts
@@ -5,6 +5,7 @@
 import type { Stmt, ArgumentsBlock } from "../parser/types.js";
 import type { Runtime } from "../runtime/runtime.js";
 import type { RuntimeValue } from "../runtime/types.js";
+import { incref, decref } from "../runtime/refcount.js";
 
 // ── Control flow signals ─────────────────────────────────────────────────
 
@@ -81,14 +82,19 @@ export class Environment {
     return this.vars.get(name) ?? this.parent?.get(name);
   }
 
-  /** Set variable — for nested scopes, writes to parent if variable exists there. */
+  /** Set variable — for nested scopes, writes to parent if variable
+   *  exists there. Maintains refcounts: increfs the new value, decrefs
+   *  the slot's prior occupant (in that order so self-rebind is safe). */
   set(name: string, value: RuntimeValue): void {
     if (
       this._globalNames !== undefined &&
       this._globalNames.has(name) &&
       this.rt
     ) {
+      const old = this.rt.$g[name];
+      incref(value);
       this.rt.$g[name] = value;
+      if (old !== undefined) decref(this.rt, old);
       return;
     }
     if (this.isNested && !this.vars.has(name) && this.parent) {
@@ -98,12 +104,15 @@ export class Environment {
         return;
       }
     }
-    this.vars.set(name, value);
+    this.setLocal(name, value);
   }
 
   /** Always writes to this scope (for parameter binding). */
   setLocal(name: string, value: RuntimeValue): void {
+    const old = this.vars.get(name);
+    incref(value);
     this.vars.set(name, value);
+    if (old !== undefined && this.rt) decref(this.rt, old);
   }
 
   /** Remove a variable from this scope's local map.
@@ -112,12 +121,19 @@ export class Environment {
    *  are removed via `clear global` / `clear functions` (not yet
    *  implemented). */
   delete(name: string): boolean {
-    return this.vars.delete(name);
+    if (!this.vars.has(name)) return false;
+    const old = this.vars.get(name)!;
+    this.vars.delete(name);
+    if (this.rt) decref(this.rt, old);
+    return true;
   }
 
   /** Remove all local variables from this scope. Globals,
    *  persistents, and nested function defs are preserved. */
   clearLocals(): void {
+    if (this.rt) {
+      for (const v of this.vars.values()) decref(this.rt, v);
+    }
     this.vars.clear();
   }
 
@@ -175,12 +191,16 @@ export class Environment {
   }
 
   /** Create a snapshot of this environment (copies all variables by value).
-   *  Used for anonymous functions which capture values at definition time. */
+   *  Used for anonymous functions which capture values at definition time.
+   *  Each captured value is incref'd so it survives the source env's
+   *  clearLocals when the original frame returns. */
   snapshot(): Environment {
     const snap = new Environment();
+    snap.rt = this.rt;
     const copyVars = (env: Environment) => {
       if (env.parent) copyVars(env.parent);
       for (const [k, v] of env.vars) {
+        incref(v);
         snap.vars.set(k, v);
       }
       for (const [k, v] of env.nestedFunctions) {
@@ -188,7 +208,6 @@ export class Environment {
       }
     };
     copyVars(this);
-    snap.rt = this.rt;
     snap.globalNames = new Set(this.globalNames);
     return snap;
   }

--- a/src/numbl-core/runtime/constructors.ts
+++ b/src/numbl-core/runtime/constructors.ts
@@ -1,25 +1,25 @@
 /**
- * RuntimeValue constructor helpers (the MV namespace).
+ * RuntimeValue constructor helpers (the RTV namespace).
  */
 
 import { allocFloat64Array } from "../executors/jsJit/helpers/alloc.js";
 import { ItemType } from "../lowering/itemTypes.js";
 import {
   type RuntimeNumber,
-  type RuntimeTensor,
+  RuntimeTensor,
   type RuntimeString,
-  type RuntimeChar,
+  RuntimeChar,
   type RuntimeLogical,
-  type RuntimeCell,
-  type RuntimeStruct,
-  type RuntimeFunction,
-  type RuntimeClassInstance,
-  type RuntimeComplexNumber,
-  type RuntimeDummyHandle,
-  type RuntimeGraphicsHandle,
-  type RuntimeStructArray,
-  type RuntimeSparseMatrix,
-  type RuntimeDictionary,
+  RuntimeCell,
+  RuntimeStruct,
+  RuntimeFunction,
+  RuntimeClassInstance,
+  RuntimeComplexNumber,
+  RuntimeDummyHandle,
+  RuntimeGraphicsHandle,
+  RuntimeStructArray,
+  RuntimeSparseMatrix,
+  RuntimeDictionary,
   type RuntimeValue,
   isRuntimeNumber,
   isRuntimeLogical,
@@ -45,12 +45,12 @@ export const RTV = {
     // Strip trailing singleton dimensions (always keeps minimum 2D)
     const s = [...shape];
     while (s.length > 2 && s[s.length - 1] === 1) s.pop();
-    return { kind: "tensor", data: d, imag: im, shape: s };
+    return new RuntimeTensor(d, s, im);
   },
 
   /** Fast tensor constructor — data must be Float64Array, shape already normalized (no trailing singletons). */
   tensorRaw(data: Float64Array, shape: number[]): RuntimeTensor {
-    return { kind: "tensor", data, imag: undefined, shape };
+    return new RuntimeTensor(data, shape);
   },
 
   /** Create a scalar tensor (1x1) */
@@ -61,23 +61,13 @@ export const RTV = {
   /** Create a row vector [1 x n] */
   row(data: number[], imag?: number[]): RuntimeTensor {
     const im = imag ? allocFloat64Array(imag) : undefined;
-    return {
-      kind: "tensor",
-      data: allocFloat64Array(data),
-      imag: im,
-      shape: [1, data.length],
-    };
+    return new RuntimeTensor(allocFloat64Array(data), [1, data.length], im);
   },
 
   /** Create a column vector [n x 1] */
   col(data: number[], imag?: number[]): RuntimeTensor {
     const im = imag ? allocFloat64Array(imag) : undefined;
-    return {
-      kind: "tensor",
-      data: allocFloat64Array(data),
-      imag: im,
-      shape: [data.length, 1],
-    };
+    return new RuntimeTensor(allocFloat64Array(data), [data.length, 1], im);
   },
 
   /** Create a matrix from row-major data */
@@ -93,12 +83,7 @@ export const RTV = {
         ? imag
         : allocFloat64Array(imag)
       : undefined;
-    return {
-      kind: "tensor",
-      data: d,
-      imag: im,
-      shape: [rows, cols],
-    };
+    return new RuntimeTensor(d, [rows, cols], im);
   },
 
   string(value: string): RuntimeString {
@@ -106,7 +91,7 @@ export const RTV = {
   },
 
   char(value: string): RuntimeChar {
-    return { kind: "char", value };
+    return new RuntimeChar(value);
   },
 
   logical(value: boolean): RuntimeLogical {
@@ -114,7 +99,7 @@ export const RTV = {
   },
 
   cell(data: RuntimeValue[], shape: number[]): RuntimeCell {
-    return { kind: "cell", data, shape: [...shape] };
+    return new RuntimeCell(data, [...shape]);
   },
 
   struct(
@@ -122,7 +107,7 @@ export const RTV = {
   ): RuntimeStruct {
     const map =
       fields instanceof Map ? fields : new Map(Object.entries(fields));
-    return { kind: "struct", fields: map };
+    return new RuntimeStruct(map);
   },
 
   func(
@@ -130,7 +115,7 @@ export const RTV = {
     impl: "builtin" | "user",
     captures: RuntimeValue[] = []
   ): RuntimeFunction {
-    return { kind: "function", name, impl, captures };
+    return new RuntimeFunction(name, impl, captures);
   },
 
   classInstance(
@@ -147,34 +132,29 @@ export const RTV = {
         defaults?.get(name) ?? RTV.tensor(allocFloat64Array(0), [0, 0])
       );
     }
-    return {
-      kind: "class_instance",
-      className,
-      fields,
-      isHandleClass,
-    };
+    return new RuntimeClassInstance(className, fields, isHandleClass);
   },
 
   complex(re: number, im: number): RuntimeComplexNumber {
-    return { kind: "complex_number", re, im };
+    return new RuntimeComplexNumber(re, im);
   },
 
   dummyHandle(): RuntimeDummyHandle {
-    return { kind: "dummy_handle" };
+    return new RuntimeDummyHandle();
   },
 
   graphicsHandle(
     trace: Record<string, unknown>,
     traceType: string
   ): RuntimeGraphicsHandle {
-    return { kind: "graphics_handle", _trace: trace, _traceType: traceType };
+    return new RuntimeGraphicsHandle(trace, traceType);
   },
 
   structArray(
     fieldNames: string[],
     elements: RuntimeStruct[]
   ): RuntimeStructArray {
-    return { kind: "struct_array", fieldNames, elements };
+    return new RuntimeStructArray(fieldNames, elements);
   },
 
   sparseMatrix(
@@ -185,7 +165,7 @@ export const RTV = {
     pr: Float64Array,
     pi?: Float64Array
   ): RuntimeSparseMatrix {
-    return { kind: "sparse_matrix", m, n, ir, jc, pr, pi };
+    return new RuntimeSparseMatrix(m, n, ir, jc, pr, pi);
   },
 
   dictionary(
@@ -193,12 +173,7 @@ export const RTV = {
     keyType?: string,
     valueType?: string
   ): RuntimeDictionary {
-    return {
-      kind: "dictionary",
-      entries: entries ?? new Map(),
-      keyType,
-      valueType,
-    };
+    return new RuntimeDictionary(entries, keyType, valueType);
   },
 };
 

--- a/src/numbl-core/runtime/index.ts
+++ b/src/numbl-core/runtime/index.ts
@@ -1,8 +1,6 @@
-export type {
-  RuntimeValue,
+export type { RuntimeValue, RuntimeString, RuntimeLogical } from "./types.js";
+export {
   RuntimeTensor,
-  RuntimeString,
-  RuntimeLogical,
   RuntimeCell,
   RuntimeStruct,
   RuntimeFunction,

--- a/src/numbl-core/runtime/indexing.ts
+++ b/src/numbl-core/runtime/indexing.ts
@@ -715,16 +715,20 @@ function indexIntoTensor(
       tail *= base.shape[d];
     }
     collapsedShape.push(tail);
-    const view = new RuntimeTensor(
-      base.data,
-      collapsedShape,
-      base.imag,
-      base._isLogical
-    );
-    if (indices.length === 2) {
-      return indexIntoTensor2D(view, indices[0], indices[1]);
+    // Swap base.shape for the call duration so the indexing helpers see
+    // the collapsed view without us constructing a new wrapper that
+    // shares base.data (which would tie the buffer's pool-release to
+    // two wrappers).
+    const savedShape = base.shape;
+    base.shape = collapsedShape;
+    try {
+      if (indices.length === 2) {
+        return indexIntoTensor2D(base, indices[0], indices[1]);
+      }
+      return indexIntoTensorND(base, indices);
+    } finally {
+      base.shape = savedShape;
     }
-    return indexIntoTensorND(view, indices);
   }
   if (indices.length === 2) {
     return indexIntoTensor2D(base, indices[0], indices[1]);

--- a/src/numbl-core/runtime/indexing.ts
+++ b/src/numbl-core/runtime/indexing.ts
@@ -4,9 +4,10 @@
 
 import {
   type RuntimeValue,
-  type RuntimeTensor,
+  RuntimeTensor,
   type RuntimeCell,
   type RuntimeSparseMatrix,
+  RuntimeChar,
   isRuntimeTensor,
   isRuntimeLogical,
   isRuntimeNumber,
@@ -19,7 +20,6 @@ import {
   isRuntimeStruct,
   isRuntimeClassInstance,
   isRuntimeChar,
-  type RuntimeChar,
 } from "./types.js";
 import { RuntimeError } from "./error.js";
 import { RTV } from "./constructors.js";
@@ -710,7 +710,12 @@ function indexIntoTensor(
       tail *= base.shape[d];
     }
     collapsedShape.push(tail);
-    const view: RuntimeTensor = { ...base, shape: collapsedShape };
+    const view = new RuntimeTensor(
+      base.data,
+      collapsedShape,
+      base.imag,
+      base._isLogical
+    );
     if (indices.length === 2) {
       return indexIntoTensor2D(view, indices[0], indices[1]);
     }
@@ -1039,12 +1044,7 @@ function indexIntoChar(
     }
 
     if (rows.length <= 1) return RTV.char(result);
-    const resultChar: RuntimeChar = {
-      kind: "char",
-      value: result,
-      shape: [rows.length, cols.length],
-    };
-    return resultChar;
+    return new RuntimeChar(result, [rows.length, cols.length]);
   }
 
   throw new RuntimeError("Char indexing supports 1 or 2 dimensions");
@@ -2091,7 +2091,7 @@ export function storeIntoRTValueIndex(
         if (imag && S.pi) imag[idx] = S.pi[k];
       }
     }
-    rhs = { kind: "tensor", data, imag, shape: [S.m, S.n] };
+    rhs = RTV.tensor(data, [S.m, S.n], imag);
   }
 
   if (isRuntimeTensor(base)) {

--- a/src/numbl-core/runtime/indexing.ts
+++ b/src/numbl-core/runtime/indexing.ts
@@ -26,7 +26,12 @@ import { RTV } from "./constructors.js";
 import { tensorSize2D, colMajorIndex, sub2ind } from "./utils.js";
 import { toNumber } from "./convert.js";
 import { isAliased, type AliasRuntime } from "./aliasing.js";
+import { type RefcountRuntime, decref } from "./refcount.js";
 import { allocFloat64Array } from "../executors/jsJit/helpers/alloc.js";
+
+/** Runtime surface needed by index-store mutations: alias-sweep + refcount.
+ *  The full Runtime class satisfies both structurally. */
+type StoreRuntime = AliasRuntime & RefcountRuntime;
 
 // ── Anti-aliasing helper ─────────────────────────────────────────────────
 
@@ -1907,7 +1912,7 @@ function storeIntoCell(
   indices: RuntimeValue[],
   rhs: RuntimeValue,
   parenAssign = false,
-  rt?: AliasRuntime
+  rt?: StoreRuntime
 ): RuntimeValue {
   // Sweep-based COW for the cell wrapper.
   if (mustCopyForAlias(base, rt)) {
@@ -1928,14 +1933,40 @@ function storeIntoCell(
       indices[0],
       rhs,
       updateShapeAfterLinearAssign,
-      parenAssign
+      parenAssign,
+      rt
     );
   }
   if (indices.length === 2) {
-    return storeIntoCell2D(base, indices, rhs, parenAssign);
+    return storeIntoCell2D(base, indices, rhs, parenAssign, rt);
   }
 
   throw new RuntimeError(`Cannot index-assign into cell`);
+}
+
+/** Append a fresh empty tensor onto cell.data with proper incref so the
+ *  cell takes ownership. The empty tensor has rc=0 at construction; after
+ *  this helper, it has rc=1 (owned by the cell). */
+function appendEmptyCellSlot(cell: RuntimeCell, rt?: RefcountRuntime): void {
+  const empty = RTV.tensor(allocFloat64Array(0), [0, 0]);
+  if (rt) empty.incref();
+  cell.data.push(empty);
+}
+
+/** Replace cell.data[pos] with rhs, decref-old / incref-new. The cell's
+ *  data is mutated in place; if rt is unavailable, refcount work is
+ *  skipped (lax mode). */
+function setCellElement(
+  cell: RuntimeCell,
+  pos: number,
+  value: RuntimeValue,
+  rt?: RefcountRuntime
+): void {
+  if (rt) {
+    cell.bindElement(rt, pos, value);
+  } else {
+    cell.data[pos] = value;
+  }
 }
 
 function storeIntoCell1D(
@@ -1943,7 +1974,8 @@ function storeIntoCell1D(
   idx: RuntimeValue,
   rhs: RuntimeValue,
   updateShape: (oldLen: number) => void,
-  parenAssign = false
+  parenAssign = false,
+  rt?: RefcountRuntime
 ): RuntimeValue {
   // Vector index
   if (isRuntimeTensor(idx)) {
@@ -1962,9 +1994,8 @@ function storeIntoCell1D(
       const pos = positions[0];
       if (pos < 0) throw new RuntimeError("Cell index exceeds bounds");
       const oldLen = base.data.length;
-      while (base.data.length <= pos)
-        base.data.push(RTV.tensor(allocFloat64Array(0), [0, 0]));
-      base.data[pos] = rhs;
+      while (base.data.length <= pos) appendEmptyCellSlot(base, rt);
+      setCellElement(base, pos, rhs, rt);
       updateShape(oldLen);
       return base;
     }
@@ -1982,11 +2013,10 @@ function storeIntoCell1D(
       if (pos < 0) throw new RuntimeError("Cell index exceeds bounds");
       if (pos > maxIdx) maxIdx = pos;
     }
-    while (base.data.length <= maxIdx)
-      base.data.push(RTV.tensor(allocFloat64Array(0), [0, 0]));
+    while (base.data.length <= maxIdx) appendEmptyCellSlot(base, rt);
     for (let j = 0; j < positions.length; j++) {
       const pos = positions[j];
-      base.data[pos] = scalarExpand ? rhs.data[0] : rhs.data[j];
+      setCellElement(base, pos, scalarExpand ? rhs.data[0] : rhs.data[j], rt);
     }
     updateShape(oldLen);
     return base;
@@ -1997,14 +2027,14 @@ function storeIntoCell1D(
   if (i < 0) throw new RuntimeError("Cell index exceeds bounds");
   const oldLen = base.data.length;
   if (i >= base.data.length) {
-    while (base.data.length <= i)
-      base.data.push(RTV.tensor(allocFloat64Array(0), [0, 0]));
+    while (base.data.length <= i) appendEmptyCellSlot(base, rt);
   }
   // Unwrap 1x1 cell RHS only for paren assignment: c(i) = {val} stores val
-  base.data[i] =
+  const newVal =
     parenAssign && isRuntimeCell(rhs) && rhs.data.length === 1
       ? rhs.data[0]
       : rhs;
+  setCellElement(base, i, newVal, rt);
   updateShape(oldLen);
   return base;
 }
@@ -2013,7 +2043,8 @@ function storeIntoCell2D(
   base: RuntimeCell,
   indices: RuntimeValue[],
   rhs: RuntimeValue,
-  parenAssign = false
+  parenAssign = false,
+  rt?: RefcountRuntime
 ): RuntimeValue {
   let rows = base.shape[0];
   let cols = base.shape.length >= 2 ? base.shape[1] : 1;
@@ -2028,14 +2059,26 @@ function storeIntoCell2D(
   const newRows = Math.max(rows, maxRow);
   const newCols = Math.max(cols, maxCol);
   if (newRows > rows || newCols > cols) {
-    const emptyVal = () => RTV.tensor(allocFloat64Array(0), [0, 0]);
     const newData: RuntimeValue[] = new Array(newRows * newCols);
-    for (let k = 0; k < newData.length; k++) newData[k] = emptyVal();
+    for (let k = 0; k < newData.length; k++) {
+      const empty = RTV.tensor(allocFloat64Array(0), [0, 0]);
+      if (rt) empty.incref();
+      newData[k] = empty;
+    }
+    // Move existing elements (refcount unchanged — cell already owned them).
     for (let j = 0; j < cols; j++) {
       for (let i = 0; i < rows; i++) {
+        const oldEmpty = newData[j * newRows + i];
         newData[j * newRows + i] = base.data[j * rows + i];
+        if (rt) decref(rt, oldEmpty);
       }
     }
+    // Decref the old (smaller) data array's elements that are no longer held.
+    // base.data's elements were either copied above or are now slots in
+    // newData; the "moved" ones are held in newData with the same refcount.
+    // Since we've already replaced their slot in newData (from empty to old),
+    // those old elements' rc is unchanged. The empty placeholders we
+    // overwrote were decref'd above.
     base.data = newData;
     base.shape = [newRows, newCols];
     rows = newRows;
@@ -2055,12 +2098,17 @@ function storeIntoCell2D(
     for (let cj = 0; cj < nSelectedCols; cj++) {
       for (let ri = 0; ri < nSelectedRows; ri++) {
         const linearIdx = colIndices[cj] * rows + rowIndices[ri];
-        base.data[linearIdx] = scalarExpand ? rhs.data[0] : rhs.data[k++];
+        setCellElement(
+          base,
+          linearIdx,
+          scalarExpand ? rhs.data[0] : rhs.data[k++],
+          rt
+        );
       }
     }
   } else {
     const linearIdx = colIndices[0] * rows + rowIndices[0];
-    base.data[linearIdx] = rhs;
+    setCellElement(base, linearIdx, rhs, rt);
   }
   return base;
 }
@@ -2073,7 +2121,7 @@ export function storeIntoRTValueIndex(
   indices: RuntimeValue[],
   rhs: RuntimeValue,
   parenAssign = false,
-  rt?: AliasRuntime
+  rt?: StoreRuntime
 ): RuntimeValue {
   if (isRuntimeSparseMatrix(base)) {
     return storeIntoSparse(base, indices, rhs);

--- a/src/numbl-core/runtime/memoryPool.ts
+++ b/src/numbl-core/runtime/memoryPool.ts
@@ -15,9 +15,13 @@
 
 // ── Runtime stack ────────────────────────────────────────────────────────
 
-interface PoolHolder {
-  pool: MemoryPool;
-}
+import type { RefcountRuntime } from "./refcount.js";
+
+/** Minimal shape needed to find the active pool + transient scope.
+ *  `Runtime` (and any test stub) must satisfy this; it intentionally
+ *  matches `RefcountRuntime` so refcount-aware code can call
+ *  `getCurrentRuntime()` and use the result without casting. */
+type PoolHolder = RefcountRuntime;
 
 const runtimeStack: PoolHolder[] = [];
 

--- a/src/numbl-core/runtime/memoryPool.ts
+++ b/src/numbl-core/runtime/memoryPool.ts
@@ -133,13 +133,18 @@ export class MemoryPool {
 
   /**
    * Return a buffer to the free pool. Caller asserts no live wrapper still
-   * references this buffer; misuse silently corrupts data. Currently
-   * unused — exposed so a future reclamation strategy (refcount, GC-based,
-   * region-based) can plug in without touching alloc-side code.
+   * references this buffer; misuse corrupts data.
+   *
+   * Released buffers are poisoned with NaN so any subsequent read via a
+   * stale wrapper (use-after-free) surfaces as NaN rather than silently
+   * matching the zero-fill that `acquire` performs on reuse. The poison
+   * is overwritten on the next `acquire` (zero-fill) or `acquireFrom`
+   * (set from src), so live consumers never see it.
    */
   release(buf: Float64Array): void {
     if (!this.liveSet.has(buf)) return;
     this.liveSet.delete(buf);
+    buf.fill(NaN);
     let bucket = this.freePool.get(buf.length);
     if (!bucket) {
       bucket = [];

--- a/src/numbl-core/runtime/refcount.ts
+++ b/src/numbl-core/runtime/refcount.ts
@@ -1,0 +1,109 @@
+/**
+ * Refcount-driven pool reclamation for RuntimeValue containers.
+ *
+ * Every container kind extends `Refcounted`. The count starts at 0
+ * (newly-constructed value, not yet bound to anything). It's incremented
+ * when a slot (env binding, struct field, cell element, ...) takes
+ * ownership, and decremented when the slot releases ownership. When the
+ * count reaches 0, `_destroy` runs: every child value is decref'd and
+ * any owned buffers are returned to the pool.
+ *
+ * Strict mode (`rt.strictRefcount`) makes a decref of an already-zero
+ * count throw. Pool reclamation is gated by `rt.poolReclaim` — until
+ * the flag is on, `_destroy` skips the buffer release. Both flags
+ * default off until later phases of the refcount rollout finish.
+ */
+
+/** Minimal runtime surface used by the refcount API. The real `Runtime`
+ *  class satisfies this, but using an interface here avoids a circular
+ *  import between refcount.ts ↔ runtime.ts ↔ types.ts. */
+export interface RefcountRuntime {
+  pool: { release(buf: Float64Array): void };
+  /** When true, decref of a zero count throws. */
+  strictRefcount?: boolean;
+  /** When true, `RuntimeTensor._destroy` etc. release buffers to the pool. */
+  poolReclaim?: boolean;
+  /** Optional transients harness. Constructors push freshly-built values
+   *  here so an unbound expression result is decref'd at end of statement. */
+  currentScope?: RefScope | null;
+}
+
+/** Base class for every refcounted runtime value. */
+export abstract class Refcounted {
+  /** Public so type guards can look for a `kind` discriminator without
+   *  walking the prototype. The string is set by every subclass. */
+  abstract readonly kind: string;
+
+  /** Reference count. Starts at 0; incremented when bound to a slot. */
+  _rc: number = 0;
+
+  incref(): void {
+    this._rc++;
+  }
+
+  decref(rt: RefcountRuntime): void {
+    if (this._rc <= 0) {
+      if (rt.strictRefcount) {
+        throw new Error(`refcount underflow on ${this.kind} (rc=${this._rc})`);
+      }
+      // Lax mode: silently ignore, plumbing can be incomplete during migration.
+      return;
+    }
+    this._rc--;
+    if (this._rc === 0) {
+      this._destroy(rt);
+    }
+  }
+
+  /** Subclasses release child refs and any owned buffers. Idempotent
+   *  must NOT be assumed — callers guarantee this fires exactly once. */
+  protected abstract _destroy(rt: RefcountRuntime): void;
+}
+
+/** True if the value is a container that participates in refcounting.
+ *  Primitives (number, boolean, string) return false. */
+export function isRefcountable(v: unknown): v is Refcounted {
+  return v instanceof Refcounted;
+}
+
+/** Increment refcount on a value if it's a container; primitives are noop. */
+export function incref(v: unknown): void {
+  if (v instanceof Refcounted) v.incref();
+}
+
+/** Decrement refcount on a value if it's a container; primitives are noop. */
+export function decref(rt: RefcountRuntime, v: unknown): void {
+  if (v instanceof Refcounted) v.decref(rt);
+}
+
+/** Per-statement transients harness. Fresh values produced by constructors
+ *  and operators are adopted here at rc=1; on `drain`, every member is
+ *  decref'd. Anything bound to a slot during the statement gets an extra
+ *  incref from the slot, so it survives drain at slot count.
+ *
+ *  The harness is wired up in phase 5 of the refcount rollout. Until
+ *  then, `RTV.*` factories may construct without adopting. */
+export class RefScope {
+  private members: Refcounted[] = [];
+
+  /** Take ownership of a fresh value: incref and remember for drain. */
+  adopt(v: unknown): void {
+    if (v instanceof Refcounted) {
+      v.incref();
+      this.members.push(v);
+    }
+  }
+
+  /** Release every adopted value. Called in `withScope`'s finally. */
+  drain(rt: RefcountRuntime): void {
+    for (const v of this.members) {
+      v.decref(rt);
+    }
+    this.members.length = 0;
+  }
+
+  /** Number of currently-adopted values (for assertions/tests). */
+  size(): number {
+    return this.members.length;
+  }
+}

--- a/src/numbl-core/runtime/refcount.ts
+++ b/src/numbl-core/runtime/refcount.ts
@@ -56,8 +56,13 @@ export abstract class Refcounted {
   }
 
   /** Subclasses release child refs and any owned buffers. Idempotent
-   *  must NOT be assumed — callers guarantee this fires exactly once. */
-  protected abstract _destroy(rt: RefcountRuntime): void;
+   *  must NOT be assumed — callers guarantee this fires exactly once.
+   *  Default is a no-op for kinds that own no buffers and have no child
+   *  refs (RuntimeChar, RuntimeComplexNumber, RuntimeDummyHandle, etc.). */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected _destroy(_rt: RefcountRuntime): void {
+    // no-op default
+  }
 }
 
 /** True if the value is a container that participates in refcounting.

--- a/src/numbl-core/runtime/refcount.ts
+++ b/src/numbl-core/runtime/refcount.ts
@@ -1,5 +1,5 @@
 /**
- * Refcount-driven pool reclamation for RuntimeValue containers.
+ * Refcount-driven memory-pool reclamation for RuntimeValue containers.
  *
  * Every container kind extends `Refcounted`. The count starts at 0
  * (newly-constructed value, not yet bound to anything). It's incremented
@@ -9,9 +9,10 @@
  * any owned buffers are returned to the pool.
  *
  * Strict mode (`rt.strictRefcount`) makes a decref of an already-zero
- * count throw. Pool reclamation is gated by `rt.poolReclaim` — until
- * the flag is on, `_destroy` skips the buffer release. Both flags
- * default off until later phases of the refcount rollout finish.
+ * count throw. The memory pool is gated by `rt.memPool` — when off,
+ * `_destroy` skips the buffer release so every allocation is a fresh
+ * `new Float64Array` and no buffer is ever recycled. Useful for
+ * isolating bugs that may be caused by buffer recycling.
  */
 
 import { getCurrentRuntime } from "./memoryPool.js";
@@ -27,8 +28,12 @@ export interface RefcountRuntime {
   };
   /** When true, decref of a zero count throws. */
   strictRefcount?: boolean;
-  /** When true, `RuntimeTensor._destroy` etc. release buffers to the pool. */
-  poolReclaim?: boolean;
+  /** When true, `RuntimeTensor._destroy` etc. release buffers back to
+   *  the pool for reuse. When false, buffers are dropped on the floor
+   *  (JS GC reclaims the wrapper; the underlying `Float64Array` is
+   *  collected with it) and every allocation is a fresh
+   *  `new Float64Array`. */
+  memPool?: boolean;
   /** Optional transients harness. Constructors push freshly-built values
    *  here so an unbound expression result is decref'd at end of statement. */
   currentScope?: RefScope | null;

--- a/src/numbl-core/runtime/refcount.ts
+++ b/src/numbl-core/runtime/refcount.ts
@@ -14,11 +14,17 @@
  * default off until later phases of the refcount rollout finish.
  */
 
+import { getCurrentRuntime } from "./memoryPool.js";
+
 /** Minimal runtime surface used by the refcount API. The real `Runtime`
  *  class satisfies this, but using an interface here avoids a circular
  *  import between refcount.ts ↔ runtime.ts ↔ types.ts. */
 export interface RefcountRuntime {
-  pool: { release(buf: Float64Array): void };
+  pool: {
+    acquire(size: number): Float64Array;
+    acquireFrom(src: number[] | Float64Array): Float64Array;
+    release(buf: Float64Array): void;
+  };
   /** When true, decref of a zero count throws. */
   strictRefcount?: boolean;
   /** When true, `RuntimeTensor._destroy` etc. release buffers to the pool. */
@@ -36,6 +42,21 @@ export abstract class Refcounted {
 
   /** Reference count. Starts at 0; incremented when bound to a slot. */
   _rc: number = 0;
+
+  constructor() {
+    // Auto-adopt into the active runtime's transient scope (if any). The
+    // scope owns one ref (rc=0 → 1) so the value survives until the
+    // current statement finishes. Statements that bind the value to a
+    // slot (env, struct field, cell element, ...) add their own refs;
+    // statements that don't get the value released on scope drain.
+    //
+    // In production code the current runtime is always set during
+    // execution. Test harnesses that build values without an active
+    // runtime simply skip adoption — the rc stays at 0 and JS GC
+    // collects the wrapper on its own.
+    const rt = getCurrentRuntime();
+    if (rt && rt.currentScope) rt.currentScope.adopt(this);
+  }
 
   incref(): void {
     this._rc++;

--- a/src/numbl-core/runtime/runtime.ts
+++ b/src/numbl-core/runtime/runtime.ts
@@ -238,11 +238,14 @@ export class Runtime {
   public currentScope: RefScope | null = null;
 
   /** When true, RuntimeTensor / RuntimeSparseMatrix `_destroy` releases
-   *  owned buffers back to `this.pool`. */
-  public poolReclaim: boolean = true;
+   *  owned buffers back to `this.pool` for reuse. When false, buffers
+   *  are dropped on the floor (JS GC reclaims them) and every
+   *  allocation is a fresh `new Float64Array` — useful for isolating
+   *  bugs that may be caused by buffer recycling. CLI: `--no-mem-pool`. */
+  public memPool: boolean = true;
 
   /** When true, `decref` on a zero count throws (loud at the
-   *  underflow site rather than silently leaking or, in `poolReclaim`
+   *  underflow site rather than silently leaking or, in `memPool`
    *  mode, double-releasing a buffer). Off by default — chained-lvalue
    *  assignments (e.g. `T.x(1).y = 10`) currently produce harmless
    *  underflows during scope drain, so flipping this on requires a

--- a/src/numbl-core/runtime/runtime.ts
+++ b/src/numbl-core/runtime/runtime.ts
@@ -26,6 +26,7 @@ import {
   CancellationError,
   type CallFrame,
 } from "../runtime/index.js";
+import { incref, decref } from "./refcount.js";
 import {
   isRuntimeNumber,
   isRuntimeTensor,
@@ -1213,7 +1214,10 @@ export class Runtime {
       funcMap = new Map();
       this.persistentStore.set(funcId, funcMap);
     }
+    const old = funcMap.get(varName);
+    incref(value);
     funcMap.set(varName, value);
+    if (old !== undefined) decref(this, old);
   }
 
   // ── Thin wrappers to runtimeOperators ─────────────────────────────

--- a/src/numbl-core/runtime/runtime.ts
+++ b/src/numbl-core/runtime/runtime.ts
@@ -241,8 +241,13 @@ export class Runtime {
    *  owned buffers back to `this.pool`. */
   public poolReclaim: boolean = true;
 
-  /** When true, `decref` on a zero count throws. Default off until
-   *  phase 6 of the refcount rollout flips it on. */
+  /** When true, `decref` on a zero count throws (loud at the
+   *  underflow site rather than silently leaking or, in `poolReclaim`
+   *  mode, double-releasing a buffer). Off by default — chained-lvalue
+   *  assignments (e.g. `T.x(1).y = 10`) currently produce harmless
+   *  underflows during scope drain, so flipping this on requires a
+   *  cleanup pass over `setMemberReturn` / `indexStore` callbacks.
+   *  Enabled in tests as a debugging aid. */
   public strictRefcount: boolean = false;
 
   // Accessor guard: prevents recursive getter/setter/subsref calls

--- a/src/numbl-core/runtime/runtime.ts
+++ b/src/numbl-core/runtime/runtime.ts
@@ -26,7 +26,7 @@ import {
   CancellationError,
   type CallFrame,
 } from "../runtime/index.js";
-import { incref, decref } from "./refcount.js";
+import { incref, decref, RefScope } from "./refcount.js";
 import {
   isRuntimeNumber,
   isRuntimeTensor,
@@ -227,10 +227,24 @@ export class Runtime {
   public _envStack: import("./aliasing.js").AliasEnv[] = [];
 
   /** Float64Array memory pool. Initialized in the constructor; consulted
-   *  by `allocFloat64Array`. Currently tracks allocations and reports
-   *  stats; reclamation (sweep / refcount / GC) is intentionally absent
-   *  in this iteration. */
+   *  by `allocFloat64Array`. */
   public pool!: import("./memoryPool.js").MemoryPool;
+
+  /** Active per-statement transient scope. New refcounted values are
+   *  auto-adopted into this scope (rc 0→1) on construction so they
+   *  survive long enough to be bound somewhere; on scope drain at end
+   *  of statement, anything still held only by the scope is decref'd
+   *  to 0 and destroyed. Null when no statement is in flight. */
+  public currentScope: RefScope | null = null;
+
+  /** When true, RuntimeTensor / RuntimeSparseMatrix `_destroy` releases
+   *  owned buffers back to `this.pool`. Default off until phase 4 of
+   *  the refcount rollout flips it on. */
+  public poolReclaim: boolean = false;
+
+  /** When true, `decref` on a zero count throws. Default off until
+   *  phase 6 of the refcount rollout flips it on. */
+  public strictRefcount: boolean = false;
 
   // Accessor guard: prevents recursive getter/setter/subsref calls
   public activeAccessors = new Set<string>();
@@ -392,6 +406,21 @@ export class Runtime {
   checkCancel(): void {
     if (this.cancelFlag && Atomics.load(this.cancelFlag, 0) !== 0) {
       throw new CancellationError();
+    }
+  }
+
+  /** Run `fn` with a fresh RefScope as `this.currentScope`. On return,
+   *  every value adopted into the scope is decref'd. Used by `execStmt`
+   *  to bound the lifetime of expression transients to one statement. */
+  public withScope<T>(fn: () => T): T {
+    const prev = this.currentScope;
+    const scope = new RefScope();
+    this.currentScope = scope;
+    try {
+      return fn();
+    } finally {
+      this.currentScope = prev;
+      scope.drain(this);
     }
   }
 

--- a/src/numbl-core/runtime/runtime.ts
+++ b/src/numbl-core/runtime/runtime.ts
@@ -1662,7 +1662,7 @@ export class Runtime {
     nameExpr: unknown,
     rhs: unknown
   ): RuntimeValue {
-    return _setMemberDynamicReturn(base, nameExpr, rhs);
+    return _setMemberDynamicReturn(this, base, nameExpr, rhs);
   }
 
   public subsrefCall(base: unknown, names: string[]): unknown {

--- a/src/numbl-core/runtime/runtime.ts
+++ b/src/numbl-core/runtime/runtime.ts
@@ -238,9 +238,8 @@ export class Runtime {
   public currentScope: RefScope | null = null;
 
   /** When true, RuntimeTensor / RuntimeSparseMatrix `_destroy` releases
-   *  owned buffers back to `this.pool`. Default off until phase 4 of
-   *  the refcount rollout flips it on. */
-  public poolReclaim: boolean = false;
+   *  owned buffers back to `this.pool`. */
+  public poolReclaim: boolean = true;
 
   /** When true, `decref` on a zero count throws. Default off until
    *  phase 6 of the refcount rollout flips it on. */
@@ -1431,7 +1430,7 @@ export class Runtime {
     target: unknown,
     superInstance: unknown
   ): unknown {
-    return _callSuperConstructor(target, superInstance);
+    return _callSuperConstructor(target, superInstance, this);
   }
   public createClassInstance(
     className: string,
@@ -1660,7 +1659,7 @@ export class Runtime {
     indices: unknown,
     results: unknown[]
   ): unknown {
-    return _multiOutputCellAssign(base, indices, results);
+    return _multiOutputCellAssign(base, indices, results, this);
   }
 
   // ── Member access ───────────────────────────────────────────────────

--- a/src/numbl-core/runtime/runtime.ts
+++ b/src/numbl-core/runtime/runtime.ts
@@ -36,9 +36,9 @@ import {
   isRuntimeSparseMatrix,
   RuntimeChar,
   RuntimeCell,
+  RuntimeClassInstanceArray,
   type RuntimeComplexNumber,
   type RuntimeClassInstance,
-  type RuntimeClassInstanceArray,
 } from "../runtime/types.js";
 import { getItemTypeFromRuntimeValue } from "../runtime/constructors.js";
 import { type ItemType } from "../lowering/itemTypes.js";
@@ -1999,11 +1999,7 @@ function defaultClassInstanceHorzcat(
 ): RuntimeClassInstance | RuntimeClassInstanceArray {
   const elements = collectClassInstances(items);
   if (elements.length === 1) return elements[0];
-  return {
-    kind: "class_instance_array",
-    className: elements[0].className,
-    elements,
-  };
+  return new RuntimeClassInstanceArray(elements[0].className, elements);
 }
 
 /** Default vertcat for class instances: creates an N×1 class instance array. */
@@ -2012,9 +2008,5 @@ function defaultClassInstanceVertcat(
 ): RuntimeClassInstance | RuntimeClassInstanceArray {
   const elements = collectClassInstances(rows);
   if (elements.length === 1) return elements[0];
-  return {
-    kind: "class_instance_array",
-    className: elements[0].className,
-    elements,
-  };
+  return new RuntimeClassInstanceArray(elements[0].className, elements);
 }

--- a/src/numbl-core/runtime/runtimeDispatch.ts
+++ b/src/numbl-core/runtime/runtimeDispatch.ts
@@ -9,7 +9,7 @@ import {
   type RuntimeValue,
   type RuntimeLogical,
   type RuntimeTensor,
-  type RuntimeFunction,
+  RuntimeFunction,
   RTV,
   toNumber,
   toString,
@@ -206,15 +206,7 @@ export function makeUserFuncHandle(
   jsFn: (...args: unknown[]) => unknown,
   nargin?: number
 ): RuntimeFunction {
-  return {
-    kind: "function",
-    name: "",
-    captures: [],
-    impl: "user",
-    jsFn,
-    jsFnExpectsNargout: true,
-    nargin,
-  };
+  return new RuntimeFunction("", "user", [], jsFn, true, nargin);
 }
 
 // ── isa ─────────────────────────────────────────────────────────────────

--- a/src/numbl-core/runtime/runtimeDispatch.ts
+++ b/src/numbl-core/runtime/runtimeDispatch.ts
@@ -33,6 +33,7 @@ import {
   kstr,
 } from "../runtime/types.js";
 import { isBuiltin } from "../helpers/registry.js";
+import { incref, decref } from "./refcount.js";
 import {
   getIBuiltin as _getIBuiltin,
   getIBuiltinNargin,
@@ -279,19 +280,36 @@ export function isa(
 
 export function callSuperConstructor(
   target: unknown,
-  superInstance: unknown
+  superInstance: unknown,
+  rt?: Runtime
 ): RuntimeValue {
   const targetObj = ensureRuntimeValue(target);
   const superObj = ensureRuntimeValue(superInstance);
   if (isRuntimeClassInstance(targetObj) && isRuntimeClassInstance(superObj)) {
-    // Class-to-class inheritance: merge fields from super into target
-    for (const [key, val] of superObj.fields) {
-      targetObj.fields.set(key, val);
+    // Class-to-class inheritance: merge fields from super into target.
+    // bindField does decref-old / incref-new so refcounts stay accurate
+    // even when the inherited field's value was already held by `superObj`.
+    if (rt) {
+      for (const [key, val] of superObj.fields) {
+        targetObj.bindField(rt, key, val);
+      }
+    } else {
+      for (const [key, val] of superObj.fields) {
+        targetObj.fields.set(key, val);
+      }
     }
   } else if (isRuntimeClassInstance(targetObj)) {
     // Built-in type superclass (e.g. classdef Foo < double):
-    // store the result as _builtinData
-    targetObj._builtinData = superObj;
+    // store the result as _builtinData. Incref-new / decref-old keeps
+    // the ownership transfer accounted for.
+    if (rt) {
+      const old = targetObj._builtinData;
+      incref(superObj);
+      targetObj._builtinData = superObj;
+      if (old !== undefined) decref(rt, old);
+    } else {
+      targetObj._builtinData = superObj;
+    }
   }
   return targetObj;
 }

--- a/src/numbl-core/runtime/runtimeIndexing.ts
+++ b/src/numbl-core/runtime/runtimeIndexing.ts
@@ -746,7 +746,9 @@ export function indexCellStore(
 export function multiOutputCellAssign(
   base: unknown,
   indices: unknown,
-  results: unknown[]
+  results: unknown[],
+  rt?: import("./aliasing.js").AliasRuntime &
+    import("./refcount.js").RefcountRuntime
 ): unknown {
   if (base === undefined || base === null) base = RTV.cell([], [0, 0]);
   let mv = ensureRuntimeValue(base);
@@ -775,7 +777,7 @@ export function multiOutputCellAssign(
     const idx = idxArray[i];
     const rhsMv = ensureRuntimeValue(results[i]);
     const idxMvals = resolveIndices([idx], endResolver(mv, 1));
-    mv = mIndexStore(mv, idxMvals, rhsMv) as typeof mv;
+    mv = mIndexStore(mv, idxMvals, rhsMv, false, rt) as typeof mv;
   }
 
   return mv;

--- a/src/numbl-core/runtime/runtimeIndexing.ts
+++ b/src/numbl-core/runtime/runtimeIndexing.ts
@@ -716,7 +716,8 @@ export function indexCellStore(
   base: unknown,
   indices: unknown[],
   rhs: unknown,
-  rt?: import("./aliasing.js").AliasRuntime
+  rt?: import("./aliasing.js").AliasRuntime &
+    import("./refcount.js").RefcountRuntime
 ): unknown {
   if (base === undefined || base === null) base = RTV.cell([], [0, 0]);
   let mv = ensureRuntimeValue(base);

--- a/src/numbl-core/runtime/runtimeMemberAccess.ts
+++ b/src/numbl-core/runtime/runtimeMemberAccess.ts
@@ -101,10 +101,11 @@ export function setMemberReturn(
     }
   }
   const rhsMv = ensureRuntimeValue(rhs);
-  return mSetField(mv, name, rhsMv);
+  return mSetField(mv, name, rhsMv, rt);
 }
 
 export function setMemberDynamicReturn(
+  rt: Runtime,
   base: unknown,
   nameExpr: unknown,
   rhs: unknown
@@ -112,7 +113,7 @@ export function setMemberDynamicReturn(
   const mv = ensureRuntimeValue(base);
   const name = toString(ensureRuntimeValue(nameExpr));
   const rhsMv = ensureRuntimeValue(rhs);
-  return mSetField(mv, name, rhsMv);
+  return mSetField(mv, name, rhsMv, rt);
 }
 
 /**

--- a/src/numbl-core/runtime/struct-access.ts
+++ b/src/numbl-core/runtime/struct-access.ts
@@ -11,6 +11,7 @@ import {
   kstr,
   type RuntimeValue,
 } from "./types.js";
+import type { RefcountRuntime } from "./refcount.js";
 import { RuntimeError } from "./error.js";
 import { RTV } from "./constructors.js";
 import { horzcat } from "./tensor-construction.js";
@@ -47,12 +48,20 @@ export function getRTValueField(
 export function setRTValueField(
   base: RuntimeValue,
   field: string,
-  value: RuntimeValue
+  value: RuntimeValue,
+  rt?: RefcountRuntime
 ): RuntimeValue {
   if (isRuntimeClassInstance(base)) {
     if (base.isHandleClass) {
-      // Handle class: mutate shared fields in place and return same reference
-      base.fields.set(field, value);
+      // Handle class: mutate shared fields in place and return same reference.
+      // bindField does decref-old / incref-new so the slot's refcount stays
+      // accurate. If rt isn't provided the bookkeeping is skipped (lax-mode
+      // — phase 6 will require rt at every call site).
+      if (rt) {
+        base.bindField(rt, field, value);
+      } else {
+        base.fields.set(field, value);
+      }
       return base;
     }
     // Value class: return a new instance with copied fields

--- a/src/numbl-core/runtime/struct-access.ts
+++ b/src/numbl-core/runtime/struct-access.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+  RuntimeClassInstance,
   isRuntimeClassInstance,
   isRuntimeNumber,
   isRuntimeStruct,
@@ -57,13 +58,12 @@ export function setRTValueField(
     // Value class: return a new instance with copied fields
     const newFields = new Map(base.fields);
     newFields.set(field, value);
-    return {
-      kind: "class_instance",
-      className: base.className,
-      fields: newFields,
-      isHandleClass: false,
-      _builtinData: base._builtinData,
-    };
+    return new RuntimeClassInstance(
+      base.className,
+      newFields,
+      false,
+      base._builtinData
+    );
   }
   if (isRuntimeStruct(base)) {
     const newFields = new Map(base.fields);

--- a/src/numbl-core/runtime/types.ts
+++ b/src/numbl-core/runtime/types.ts
@@ -162,7 +162,7 @@ export class RuntimeTensor extends Refcounted {
   }
 
   protected _destroy(rt: RefcountRuntime): void {
-    if (rt.poolReclaim) {
+    if (rt.memPool) {
       rt.pool.release(this.data);
       if (this.imag !== undefined) rt.pool.release(this.imag);
     }
@@ -410,7 +410,7 @@ export class RuntimeSparseMatrix extends Refcounted {
   }
 
   protected _destroy(rt: RefcountRuntime): void {
-    if (rt.poolReclaim) {
+    if (rt.memPool) {
       rt.pool.release(this.pr);
       if (this.pi !== undefined) rt.pool.release(this.pi);
     }

--- a/src/numbl-core/runtime/types.ts
+++ b/src/numbl-core/runtime/types.ts
@@ -1,5 +1,10 @@
 // Determine float precision from environment variable
-import { Refcounted, type RefcountRuntime, decref } from "./refcount.js";
+import {
+  Refcounted,
+  type RefcountRuntime,
+  incref,
+  decref,
+} from "./refcount.js";
 
 const useFloat32 = import.meta.env?.NUMBL_USE_FLOAT32 === "true" ? true : false;
 
@@ -188,6 +193,16 @@ export class RuntimeCell extends Refcounted {
     super();
     this.data = data;
     this.shape = shape;
+    for (const v of data) incref(v);
+  }
+
+  /** Replace element at idx, decref-old / incref-new. Caller resizes the
+   *  shape if necessary; this method does not touch shape. */
+  bindElement(rt: RefcountRuntime, idx: number, value: RuntimeValue): void {
+    const old = this.data[idx];
+    incref(value);
+    this.data[idx] = value;
+    if (old !== undefined) decref(rt, old);
   }
 
   protected _destroy(rt: RefcountRuntime): void {
@@ -202,6 +217,15 @@ export class RuntimeStruct extends Refcounted {
   constructor(fields: Map<string, RuntimeValue>) {
     super();
     this.fields = fields;
+    for (const v of fields.values()) incref(v);
+  }
+
+  /** Set/replace a field value, decref-old / incref-new. */
+  bindField(rt: RefcountRuntime, name: string, value: RuntimeValue): void {
+    const old = this.fields.get(name);
+    incref(value);
+    this.fields.set(name, value);
+    if (old !== undefined) decref(rt, old);
   }
 
   protected _destroy(rt: RefcountRuntime): void {
@@ -238,6 +262,7 @@ export class RuntimeFunction extends Refcounted {
     this.jsFn = jsFn;
     this.jsFnExpectsNargout = jsFnExpectsNargout;
     this.nargin = nargin;
+    for (const v of captures) incref(v);
   }
 
   protected _destroy(rt: RefcountRuntime): void {
@@ -266,6 +291,18 @@ export class RuntimeClassInstance extends Refcounted {
     this.fields = fields;
     this.isHandleClass = isHandleClass;
     this._builtinData = _builtinData;
+    for (const v of fields.values()) incref(v);
+    if (_builtinData !== undefined) incref(_builtinData);
+  }
+
+  /** Set/replace a field value (handle-class in-place mutation), with
+   *  proper decref-old / incref-new bookkeeping. Used for handle-class
+   *  field assigns; value-class field assigns construct a new instance. */
+  bindField(rt: RefcountRuntime, name: string, value: RuntimeValue): void {
+    const old = this.fields.get(name);
+    incref(value);
+    this.fields.set(name, value);
+    if (old !== undefined) decref(rt, old);
   }
 
   protected _destroy(rt: RefcountRuntime): void {
@@ -285,6 +322,7 @@ export class RuntimeClassInstanceArray extends Refcounted {
     super();
     this.className = className;
     this.elements = elements;
+    for (const el of elements) incref(el);
   }
 
   protected _destroy(rt: RefcountRuntime): void {
@@ -335,6 +373,7 @@ export class RuntimeStructArray extends Refcounted {
     super();
     this.fieldNames = fieldNames;
     this.elements = elements;
+    for (const el of elements) incref(el);
   }
 
   protected _destroy(rt: RefcountRuntime): void {
@@ -396,6 +435,10 @@ export class RuntimeDictionary extends Refcounted {
     this.entries = entries ?? new Map();
     this.keyType = keyType;
     this.valueType = valueType;
+    for (const { key, value } of this.entries.values()) {
+      incref(key);
+      incref(value);
+    }
   }
 
   protected _destroy(rt: RefcountRuntime): void {

--- a/src/numbl-core/runtime/types.ts
+++ b/src/numbl-core/runtime/types.ts
@@ -1,4 +1,6 @@
 // Determine float precision from environment variable
+import { Refcounted, type RefcountRuntime, decref } from "./refcount.js";
+
 const useFloat32 = import.meta.env?.NUMBL_USE_FLOAT32 === "true" ? true : false;
 
 export const USE_FLOAT32 = useFloat32;
@@ -124,108 +126,282 @@ export const kstr = (value: RuntimeValue): string => {
   return "unknown";
 };
 
-export type RuntimeTensor = {
-  kind: "tensor";
-  data: Float64Array; // real part
-  imag?: Float64Array; // imaginary part (optional, undefined means all zeros)
-  shape: number[]; // e.g. [3,4] for 3x4 matrix
-  /** When true, this tensor represents a logical (boolean) array from comparisons/logical ops. */
-  _isLogical?: boolean;
-};
+// ── Container classes ────────────────────────────────────────────────────
+//
+// Each class extends Refcounted. The `kind` field is preserved as an
+// instance property so the existing `value.kind === "..."` checks still
+// narrow correctly. Public mutable fields are kept for now — strict-API
+// enforcement comes in phase 3 when mutation methods replace direct
+// field writes.
 
-export type RuntimeChar = {
-  kind: "char";
+export class RuntimeTensor extends Refcounted {
+  readonly kind = "tensor" as const;
+  data: Float64Array;
+  imag: Float64Array | undefined;
+  shape: number[];
+  /** When true, this tensor represents a logical (boolean) array from
+   *  comparisons/logical ops. */
+  _isLogical: boolean | undefined;
+
+  constructor(
+    data: Float64Array,
+    shape: number[],
+    imag?: Float64Array,
+    _isLogical?: boolean
+  ) {
+    super();
+    this.data = data;
+    this.imag = imag;
+    this.shape = shape;
+    this._isLogical = _isLogical;
+  }
+
+  protected _destroy(rt: RefcountRuntime): void {
+    if (rt.poolReclaim) {
+      rt.pool.release(this.data);
+      if (this.imag !== undefined) rt.pool.release(this.imag);
+    }
+  }
+}
+
+export class RuntimeChar extends Refcounted {
+  readonly kind = "char" as const;
   value: string;
-  /** Optional shape for multi-row char arrays. If absent, shape is [1, value.length].
-   *  For multi-row arrays, value contains all rows concatenated (each row is shape[1] chars). */
-  shape?: number[];
-};
+  /** Optional shape for multi-row char arrays. If absent, shape is
+   *  [1, value.length]. For multi-row arrays, value contains all rows
+   *  concatenated (each row is shape[1] chars). */
+  shape: number[] | undefined;
 
-export type RuntimeCell = {
-  kind: "cell";
+  constructor(value: string, shape?: number[]) {
+    super();
+    this.value = value;
+    this.shape = shape;
+  }
+}
+
+export class RuntimeCell extends Refcounted {
+  readonly kind = "cell" as const;
   data: RuntimeValue[];
-  shape: number[]; // e.g. [1,3] for {a, b, c}
-};
+  shape: number[];
 
-export type RuntimeStruct = {
-  kind: "struct";
+  constructor(data: RuntimeValue[], shape: number[]) {
+    super();
+    this.data = data;
+    this.shape = shape;
+  }
+
+  protected _destroy(rt: RefcountRuntime): void {
+    for (const v of this.data) decref(rt, v);
+  }
+}
+
+export class RuntimeStruct extends Refcounted {
+  readonly kind = "struct" as const;
   fields: Map<string, RuntimeValue>;
-};
 
-export type RuntimeFunction = {
-  kind: "function";
+  constructor(fields: Map<string, RuntimeValue>) {
+    super();
+    this.fields = fields;
+  }
+
+  protected _destroy(rt: RefcountRuntime): void {
+    for (const v of this.fields.values()) decref(rt, v);
+  }
+}
+
+export class RuntimeFunction extends Refcounted {
+  readonly kind = "function" as const;
   name: string;
   /** For closures: captured variables */
   captures: RuntimeValue[];
   /** The underlying callable — either a builtin or user-defined function name */
   impl: "builtin" | "user";
   /** For anonymous functions and user function handles: the underlying JS closure */
-  jsFn?: (...args: unknown[]) => unknown;
+  jsFn: ((...args: unknown[]) => unknown) | undefined;
   /** When true, jsFn expects nargout as its first argument */
-  jsFnExpectsNargout?: boolean;
+  jsFnExpectsNargout: boolean | undefined;
   /** Number of input parameters (for nargin(handle)) */
-  nargin?: number;
-};
+  nargin: number | undefined;
 
-export type RuntimeClassInstance = {
-  kind: "class_instance";
+  constructor(
+    name: string,
+    impl: "builtin" | "user",
+    captures: RuntimeValue[],
+    jsFn?: (...args: unknown[]) => unknown,
+    jsFnExpectsNargout?: boolean,
+    nargin?: number
+  ) {
+    super();
+    this.name = name;
+    this.impl = impl;
+    this.captures = captures;
+    this.jsFn = jsFn;
+    this.jsFnExpectsNargout = jsFnExpectsNargout;
+    this.nargin = nargin;
+  }
+
+  protected _destroy(rt: RefcountRuntime): void {
+    for (const v of this.captures) decref(rt, v);
+  }
+}
+
+export class RuntimeClassInstance extends Refcounted {
+  readonly kind = "class_instance" as const;
   className: string;
   fields: Map<string, RuntimeValue>;
   /** True if this class inherits from handle (reference semantics). */
   isHandleClass: boolean;
   /** For classes that inherit from built-in types (e.g. classdef Foo < double),
    *  stores the underlying built-in data. */
-  _builtinData?: RuntimeValue;
-};
+  _builtinData: RuntimeValue | undefined;
+
+  constructor(
+    className: string,
+    fields: Map<string, RuntimeValue>,
+    isHandleClass: boolean,
+    _builtinData?: RuntimeValue
+  ) {
+    super();
+    this.className = className;
+    this.fields = fields;
+    this.isHandleClass = isHandleClass;
+    this._builtinData = _builtinData;
+  }
+
+  protected _destroy(rt: RefcountRuntime): void {
+    for (const v of this.fields.values()) decref(rt, v);
+    if (this._builtinData !== undefined) decref(rt, this._builtinData);
+  }
+}
 
 /** A 1-D array of class instances that all share the same class.
  *  Created by default horzcat/vertcat when the class doesn't overload them. */
-export type RuntimeClassInstanceArray = {
-  kind: "class_instance_array";
+export class RuntimeClassInstanceArray extends Refcounted {
+  readonly kind = "class_instance_array" as const;
   className: string;
   elements: RuntimeClassInstance[];
-};
 
-export type RuntimeComplexNumber = {
-  kind: "complex_number";
+  constructor(className: string, elements: RuntimeClassInstance[]) {
+    super();
+    this.className = className;
+    this.elements = elements;
+  }
+
+  protected _destroy(rt: RefcountRuntime): void {
+    for (const el of this.elements) decref(rt, el);
+  }
+}
+
+export class RuntimeComplexNumber extends Refcounted {
+  readonly kind = "complex_number" as const;
   re: number;
   im: number;
-};
 
-export type RuntimeDummyHandle = {
-  kind: "dummy_handle";
-};
+  constructor(re: number, im: number) {
+    super();
+    this.re = re;
+    this.im = im;
+  }
+}
+
+export class RuntimeDummyHandle extends Refcounted {
+  readonly kind = "dummy_handle" as const;
+
+  constructor() {
+    super();
+  }
+}
 
 /** Handle to a graphics object (e.g. surface returned by pcolor) with a mutable trace reference. */
-export type RuntimeGraphicsHandle = {
-  kind: "graphics_handle";
+export class RuntimeGraphicsHandle extends Refcounted {
+  readonly kind = "graphics_handle" as const;
   _trace: Record<string, unknown>;
   _traceType: string;
-};
 
-/** A 1-D array of structs that all share the same field names. **/
-export type RuntimeStructArray = {
-  kind: "struct_array";
+  constructor(_trace: Record<string, unknown>, _traceType: string) {
+    super();
+    this._trace = _trace;
+    this._traceType = _traceType;
+  }
+}
+
+/** A 1-D array of structs that all share the same field names. */
+export class RuntimeStructArray extends Refcounted {
+  readonly kind = "struct_array" as const;
   fieldNames: string[];
   elements: RuntimeStruct[];
-};
 
-/** Sparse matrix in CSC (Compressed Sparse Column) format, matching MATLAB's internal representation. */
-export type RuntimeSparseMatrix = {
-  kind: "sparse_matrix";
-  m: number; // number of rows
-  n: number; // number of columns
-  ir: Int32Array; // row indices for each nonzero (length = nnz)
-  jc: Int32Array; // column pointers (length = n + 1)
-  pr: Float64Array; // nonzero values (length = nnz)
-  pi?: Float64Array; // imaginary values (length = nnz), undefined means real
-};
+  constructor(fieldNames: string[], elements: RuntimeStruct[]) {
+    super();
+    this.fieldNames = fieldNames;
+    this.elements = elements;
+  }
+
+  protected _destroy(rt: RefcountRuntime): void {
+    for (const el of this.elements) decref(rt, el);
+  }
+}
+
+/** Sparse matrix in CSC (Compressed Sparse Column) format, matching MATLAB's
+ *  internal representation. */
+export class RuntimeSparseMatrix extends Refcounted {
+  readonly kind = "sparse_matrix" as const;
+  m: number;
+  n: number;
+  ir: Int32Array;
+  jc: Int32Array;
+  pr: Float64Array;
+  pi: Float64Array | undefined;
+
+  constructor(
+    m: number,
+    n: number,
+    ir: Int32Array,
+    jc: Int32Array,
+    pr: Float64Array,
+    pi?: Float64Array
+  ) {
+    super();
+    this.m = m;
+    this.n = n;
+    this.ir = ir;
+    this.jc = jc;
+    this.pr = pr;
+    this.pi = pi;
+  }
+
+  protected _destroy(rt: RefcountRuntime): void {
+    if (rt.poolReclaim) {
+      rt.pool.release(this.pr);
+      if (this.pi !== undefined) rt.pool.release(this.pi);
+    }
+    // ir/jc are Int32Array — pool is Float64-only, so they're left to JS GC.
+  }
+}
 
 /** Dictionary mapping unique keys to values (MATLAB R2022b+). */
-export type RuntimeDictionary = {
-  kind: "dictionary";
+export class RuntimeDictionary extends Refcounted {
+  readonly kind = "dictionary" as const;
   /** Entries keyed by a hash string of the RuntimeValue key, preserving insertion order. */
   entries: Map<string, { key: RuntimeValue; value: RuntimeValue }>;
-  keyType?: string; // e.g. "string", "double"; undefined = unconfigured
-  valueType?: string; // e.g. "double", "cell"; undefined = unconfigured
-};
+  keyType: string | undefined;
+  valueType: string | undefined;
+
+  constructor(
+    entries?: Map<string, { key: RuntimeValue; value: RuntimeValue }>,
+    keyType?: string,
+    valueType?: string
+  ) {
+    super();
+    this.entries = entries ?? new Map();
+    this.keyType = keyType;
+    this.valueType = valueType;
+  }
+
+  protected _destroy(rt: RefcountRuntime): void {
+    for (const { key, value } of this.entries.values()) {
+      decref(rt, key);
+      decref(rt, value);
+    }
+  }
+}

--- a/src/numbl-worker.ts
+++ b/src/numbl-worker.ts
@@ -9,6 +9,7 @@
  *   Main -> Worker:  { type: "run", code, options, workspaceFiles, mainFileName, searchPaths, vfsFiles, inputSAB, persistent?, cancelSAB? }
  *   Main -> Worker:  { type: "execute", code, cancelSAB? }
  *   Main -> Worker:  { type: "set_optimization", optimization }
+ *   Main -> Worker:  { type: "set_mem_pool", memPool }
  *   Main -> Worker:  { type: "update_workspace", workspaceFiles, vfsFiles, searchPaths? }
  *   Main -> Worker:  { type: "set_input_sab", inputSAB }
  *   Main -> Worker:  { type: "clear" }
@@ -47,6 +48,7 @@ let persistentSearchPaths: string[] | undefined;
 let implicitCwdPath: string | null | undefined;
 let optimizationLevel: import("./numbl-core/executors/plugins.js").OptLevel =
   "1";
+let memPoolEnabled = true;
 let vfs: VirtualFileSystem | null = null;
 let inputSAB: SharedArrayBuffer | null = null;
 const systemAdapter = new BrowserSystemAdapter();
@@ -156,6 +158,11 @@ self.onmessage = (e: MessageEvent) => {
     return;
   }
 
+  if (type === "set_mem_pool") {
+    memPoolEnabled = e.data.memPool ?? true;
+    return;
+  }
+
   if (type === "update_workspace") {
     persistentWorkspaceFiles = e.data.workspaceFiles || [];
     if (e.data.searchPaths !== undefined) {
@@ -259,6 +266,7 @@ self.onmessage = (e: MessageEvent) => {
           displayResults: options?.displayResults ?? true,
           maxIterations: options?.maxIterations ?? 10000000,
           optimization: options?.optimization ?? optimizationLevel,
+          memPool: memPoolEnabled,
           initialVariableValues: useVariableValues,
           initialHoldState: useHoldState,
           fileIO: adapter,
@@ -392,6 +400,7 @@ self.onmessage = (e: MessageEvent) => {
         displayResults: true,
         maxIterations: 10000000,
         optimization: optimizationLevel,
+        memPool: memPoolEnabled,
         initialVariableValues: variableValues,
         initialHoldState: holdState,
         fileIO: adapter,

--- a/src/vfs/BrowserFileIOAdapter.ts
+++ b/src/vfs/BrowserFileIOAdapter.ts
@@ -541,12 +541,17 @@ export class BrowserFileIOAdapter implements FileIOAdapter {
 function filterUrl(url: string): string {
   // If the url is of the form
   // https://github.com/*/releases/download/*
-  // then we need to route through a CORS proxy since GitHub doesn't send CORS headers on release assets.
+  // then we need to route through a CORS proxy since GitHub doesn't send
+  // CORS headers on release assets. Append a per-call cachebust so the
+  // browser / proxy don't serve a stale .mhl when a release tag is
+  // republished (mip-numbl is a moving tag — same URL, new content).
   if (/^https:\/\/github\.com\/.+\/releases\/download\/.+/.test(url)) {
     url = url.replace(
       "https://github.com/",
       "https://mip-cors-proxy.figurl.workers.dev/gh/"
     );
+    url += url.includes("?") ? "&" : "?";
+    url += "t=" + Date.now();
   }
   return url;
 }


### PR DESCRIPTION
## Summary

- Container values become refcounted classes (`RuntimeTensor`, `RuntimeStruct`, `RuntimeCell`, `RuntimeFunction`, etc.). Each carries `_rc` and `incref/decref/_destroy`. Type guards keep working unchanged.
- `Float64Array` buffers (tensor `data`/`imag`, sparse `pr`/`pi`) flow back to the per-runtime pool when their owning wrapper drops to refcount 0.
- Per-statement `RefScope` harness adopts fresh containers on construction; the scope drains at end of statement, releasing everything that didn't get bound to a slot.
- `Environment.set/setLocal/clearLocals/delete/snapshot`, `Runtime.setPersistent`, `setRTValueField` (handle-class), `storeIntoCell*`, `callSuperConstructor`, and `multiOutputCellAssign` route through the strict refcount API.
- `runSyntheticFnAgainstEnv` wraps JIT-compiled top-level / loop runs in `withScope` so JIT-side intermediates participate too.
- Released buffers are NaN-poisoned so any use-after-free shows up loudly.
- Pool reclamation is on by default (`rt.memPool = true`); strict-mode underflow throw is opt-in (`rt.strictRefcount`) — chained-lvalue assigns still produce harmless underflows during scope drain.

Coexists with the sweep-based COW in `aliasing.ts`. Refcount only governs wrapper-object lifecycle; COW correctness still goes through the sweep.

`reshape` and `squeeze` previously returned a wrapper aliasing the source's buffer (zero-copy); they now copy. Trade: one extra `Float64Array` copy per reshape/squeeze in exchange for single-owner buffers.

## `--no-mem-pool` (debug aid)

End-to-end opt-out for the buffer pool, useful for isolating bugs that may stem from buffer recycling:
- CLI: `--no-mem-pool` flag, threaded through `cmdRun` / `cmdEval` / `run-tests`.
- Browser worker: `set_mem_pool` message + `memPoolEnabled` state.
- IDE: `mem pool / no mem pool` toggle next to the JIT toggle in the toolbar.

When off, `_destroy` skips `pool.release` and `allocFloat64Array` skips the pool entirely (no liveSet bookkeeping, no counter increments — just `new Float64Array`). Internal field renamed `rt.poolReclaim → rt.memPool` for consistency end-to-end.

## Allocation fast paths

- Allocations ≤ 100 doubles bypass the pool unconditionally (per-acquire bookkeeping costs more than the alloc itself for small buffers; small buffers in the free list rarely help).
- Under vitest (`process.env.VITEST === "true"`), the small-alloc fast path is skipped so the test suite exercises pool semantics at every size.

## CORS-proxy cachebust

The mip-numbl release tag is mutable (same URL, latest content). `proxiedUrl` (browser auto-install) and `filterUrl` (browser `websave`/`webread`/`unzip`) now append `?t=<Date.now()>` strictly inside the GitHub-release-to-CORS-proxy rewrite branch — non-proxied URLs pass through unchanged.

## Test plan

- [x] `npm test` — 1504 unit tests green
- [x] `npm run test:scripts` — 703 integration tests green (opt 0 + opt 1)
- [x] New unit tests in `memoryPool.test.ts` verify pool releases happen for unbound transients (opt 0) and JIT top-level scope drain (opt 1)
- [x] Buffer NaN-poisoning catches use-after-free during the rollout
- [x] Smoke test of `--no-mem-pool` and small-alloc threshold confirmed end-to-end
- [x] Developer reference updated (`runtime/refcount.md`, `values-and-tensors.md`, `overview.md`, `agents.md` CLI help block)

## Phases

1. Class skeletons + plumbing — no behavior change
2. Environment slot ownership
3. Container constructor incref + bindField/bindElement; cell mutation routed through bindElement
4. `memPool` flipped on; uncovered use-after-free fixed (reshape/squeeze copy, indexing.ts collapsed-shape, min-max 'all', callSuperConstructor)
5. RefScope transient harness wired through execStmt and the JIT synthetic-fn run
6. Strict mode opt-in (chained-lvalue underflow cleanup deferred); docs

Each phase is its own commit and shippable on its own. Follow-ups (`--no-mem-pool` flag, alloc fast path, cachebust) are independent commits on top.