### PR TITLE
Add convhull and convhulln builtins

### DIFF
--- a/src/__tests__/convhull.test.ts
+++ b/src/__tests__/convhull.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { executeCode } from "../numbl-core/executeCode.js";
+import { isRuntimeTensor } from "../numbl-core/runtime/types.js";
+
+function tensor(
+  code: string,
+  varName: string
+): { data: number[]; shape: number[] } {
+  const result = executeCode(code);
+  const v = result.variableValues[varName];
+  if (!isRuntimeTensor(v)) throw new Error(`${varName} is not a tensor`);
+  return { data: Array.from(v.data), shape: v.shape };
+}
+
+function num(code: string, varName: string): number {
+  const result = executeCode(code);
+  const v = result.variableValues[varName];
+  if (typeof v !== "number") throw new Error(`${varName} is not a number`);
+  return v;
+}
+
+describe("convhull", () => {
+  it("2-D hull is a closed counter-clockwise loop of the corner indices", () => {
+    // 2x2 square plus an interior point (index 5) that must be excluded.
+    const k = tensor("k = convhull([0 0; 2 0; 2 2; 0 2; 1 1]);", "k");
+    // Column vector, closed (first == last).
+    expect(k.shape[1]).toBe(1);
+    expect(k.data[0]).toBe(k.data[k.data.length - 1]);
+    // The four corners (1..4), not the interior point (5).
+    const unique = [...new Set(k.data)].sort((a, b) => a - b);
+    expect(unique).toEqual([1, 2, 3, 4]);
+    // Counter-clockwise: signed area of the loop is positive.
+    let signed = 0;
+    const pts = [
+      [0, 0],
+      [2, 0],
+      [2, 2],
+      [0, 2],
+    ];
+    for (let i = 0; i + 1 < k.data.length; i++) {
+      const a = pts[k.data[i] - 1];
+      const b = pts[k.data[i + 1] - 1];
+      signed += a[0] * b[1] - b[0] * a[1];
+    }
+    expect(signed).toBeGreaterThan(0);
+  });
+
+  it("2-D area matches MATLAB's documented example (1.75)", () => {
+    const av = num(
+      "[k,av] = convhull([0 0; 1 1; 1.5 0.5; 1.5 -0.5; 1.25 0.3; 1 0; 1.25 -0.3; 1 -1]);",
+      "av"
+    );
+    expect(av).toBeCloseTo(1.75, 10);
+  });
+
+  it("3-D hull returns a triangle matrix and correct volume", () => {
+    // 2x2x2 cube, volume 8, surface = 12 triangles.
+    const code =
+      "[k,v] = convhull([0 0 0; 2 0 0; 2 2 0; 0 2 0; 0 0 2; 2 0 2; 2 2 2; 0 2 2]);";
+    const k = tensor(code, "k");
+    expect(k.shape).toEqual([12, 3]);
+    expect(num(code, "v")).toBeCloseTo(8, 10);
+  });
+
+  it("accepts coordinate-vector forms convhull(x,y) and convhull(x,y,z)", () => {
+    expect(tensor("k = convhull([0;2;2;0],[0;0;2;2]);", "k").shape[1]).toBe(1);
+    expect(
+      tensor(
+        "k = convhull([0;2;2;0;0;2;2;0],[0;0;2;2;0;0;2;2],[0;0;0;0;2;2;2;2]);",
+        "k"
+      ).shape
+    ).toEqual([12, 3]);
+  });
+
+  it("accepts the 'Simplify' name-value pair", () => {
+    const av = num(
+      "[k,av] = convhull([0 0; 2 0; 2 2; 0 2], 'Simplify', true);",
+      "av"
+    );
+    expect(av).toBeCloseTo(4, 10);
+  });
+});
+
+describe("convhulln", () => {
+  it("2-D returns an edge matrix and area", () => {
+    const code = "[k,a] = convhulln([0 0; 2 0; 2 2; 0 2; 1 1]);";
+    const k = tensor(code, "k");
+    expect(k.shape).toEqual([4, 2]); // 4 edges, 2 indices each
+    expect(num(code, "a")).toBeCloseTo(4, 10);
+  });
+
+  it("3-D returns a triangle matrix and volume", () => {
+    const code =
+      "[k,v] = convhulln([0 0 0; 2 0 0; 2 2 0; 0 2 0; 0 0 2; 2 0 2; 2 2 2; 0 2 2]);";
+    expect(tensor(code, "k").shape).toEqual([12, 3]);
+    expect(num(code, "v")).toBeCloseTo(8, 10);
+  });
+
+  it("rejects dimensions above 3", () => {
+    expect(() =>
+      executeCode(
+        "k = convhulln([0 0 0 0; 1 0 0 0; 0 1 0 0; 0 0 1 0; 0 0 0 1]);"
+      )
+    ).toThrow(/supported/i);
+  });
+});

--- a/src/numbl-core/interpreter/builtins/geometry.ts
+++ b/src/numbl-core/interpreter/builtins/geometry.ts
@@ -1,20 +1,23 @@
 /**
  * Interpreter IBuiltins for computational geometry functions: delaunay,
- * delaunayn, inpolygon.
+ * delaunayn, convhull, convhulln, inpolygon.
  *
- * delaunay/delaunayn are backed by the qhull WASM module, installed as the
- * Delaunay backend at startup (see geometry-bridge.ts and the qhull-node /
+ * delaunay/delaunayn/convhull/convhulln are backed by the qhull WASM module,
+ * installed at startup (see geometry-bridge.ts and the qhull-node /
  * qhull-browser loaders). The backend must be installed before these builtins
  * run; otherwise they throw.
  */
 
 import type { RuntimeValue, RuntimeTensor } from "../../runtime/types.js";
-import { isRuntimeTensor } from "../../runtime/types.js";
+import { isRuntimeTensor, isRuntimeChar } from "../../runtime/types.js";
 import { RTV, RuntimeError, tensorSize2D } from "../../runtime/index.js";
 import type { JitType } from "../../jitTypes.js";
 import { defineBuiltin } from "./types.js";
 import { allocFloat64Array } from "../../runtime/alloc.js";
-import { getDelaunayBackend } from "../../native/geometry-bridge.js";
+import {
+  getDelaunayBackend,
+  getConvexHullBackend,
+} from "../../native/geometry-bridge.js";
 
 /** Extract a flat list of numbers from a scalar or tensor argument. */
 function toFlatArray(v: RuntimeValue, name: string): number[] {
@@ -240,6 +243,285 @@ defineBuiltin({
           );
         const points = matrixToPoints(X, "delaunayn");
         return triangulateToTensor(points, n);
+      },
+    },
+  ],
+});
+
+// ── convhull / convhulln ─────────────────────────────────────────────────
+//
+// Backed by the qhull convex-hull backend (same WASM module as delaunay).
+// qhull returns the MINIMAL hull — collinear (2-D) / coplanar (3-D) points
+// that do not contribute to the hull are dropped. This matches MATLAB's
+// `Simplify=true`. The `Simplify` name-value pair (convhull) and `opts`
+// argument (convhulln) are accepted for MATLAB compatibility but do not change
+// the result; the hull geometry, area, and volume are exact in either case.
+
+const CONVHULLN_MAX_DIM = 3;
+
+/** Run the convex-hull backend, returning simplicial facets as 0-based indices. */
+function convexHullFacets(
+  points: number[][],
+  dim: number,
+  name: string
+): number[][] {
+  const backend = getConvexHullBackend();
+  if (!backend)
+    throw new RuntimeError(
+      `${name}: convex-hull backend not initialized. In Node call ` +
+        `loadQhullNodeBackend() (the CLI and library do this automatically); ` +
+        `in the browser worker it loads on startup.`
+    );
+  return backend(points, dim);
+}
+
+/** A point strictly interior to the convex hull: the mean of its vertices. */
+function hullInteriorPoint(
+  points: number[][],
+  facets: number[][],
+  dim: number
+): number[] {
+  const used = new Set<number>();
+  for (const f of facets) for (const idx of f) used.add(idx);
+  const c = new Array<number>(dim).fill(0);
+  for (const idx of used) {
+    const p = points[idx];
+    for (let k = 0; k < dim; k++) c[k] += p[k];
+  }
+  const m = used.size || 1;
+  for (let k = 0; k < dim; k++) c[k] /= m;
+  return c;
+}
+
+/** Area (dim=2) or volume (dim=3) of the hull, via a fan decomposition from an
+ *  interior point. Each boundary simplex + the interior point forms a
+ *  non-overlapping piece tiling the convex hull, so summing |measure| is exact
+ *  regardless of facet orientation. */
+function hullMeasure(
+  points: number[][],
+  facets: number[][],
+  dim: number
+): number {
+  const c = hullInteriorPoint(points, facets, dim);
+  let total = 0;
+  if (dim === 2) {
+    for (const f of facets) {
+      const a = points[f[0]];
+      const b = points[f[1]];
+      const ax = a[0] - c[0],
+        ay = a[1] - c[1];
+      const bx = b[0] - c[0],
+        by = b[1] - c[1];
+      total += Math.abs(ax * by - ay * bx) / 2;
+    }
+  } else {
+    for (const f of facets) {
+      const a = points[f[0]];
+      const b = points[f[1]];
+      const d = points[f[2]];
+      const ax = a[0] - c[0],
+        ay = a[1] - c[1],
+        az = a[2] - c[2];
+      const bx = b[0] - c[0],
+        by = b[1] - c[1],
+        bz = b[2] - c[2];
+      const dx = d[0] - c[0],
+        dy = d[1] - c[1],
+        dz = d[2] - c[2];
+      const det =
+        ax * (by * dz - bz * dy) -
+        ay * (bx * dz - bz * dx) +
+        az * (bx * dy - by * dx);
+      total += Math.abs(det) / 6;
+    }
+  }
+  return total;
+}
+
+/** Pack facets (0-based) into a numFacets-by-cols tensor of 1-based indices. */
+function facetsToTensor(facets: number[][], cols: number): RuntimeTensor {
+  const n = facets.length;
+  const out = allocFloat64Array(n * cols);
+  for (let i = 0; i < n; i++) {
+    const f = facets[i];
+    for (let j = 0; j < cols; j++) out[j * n + i] = f[j] + 1; // column-major
+  }
+  return RTV.tensor(out, [n, cols]);
+}
+
+/** Order the 2-D hull edges into a single counter-clockwise boundary loop of
+ *  1-based point indices, closed (last == first), as MATLAB's convhull returns. */
+function orderHull2D(facets: number[][], points: number[][]): RuntimeTensor {
+  // Build adjacency: each hull vertex of a convex polygon has exactly 2 edges.
+  const adj = new Map<number, number[]>();
+  for (const [a, b] of facets) {
+    (adj.get(a) ?? adj.set(a, []).get(a)!).push(b);
+    (adj.get(b) ?? adj.set(b, []).get(b)!).push(a);
+  }
+  const start = facets[0][0];
+  const loop: number[] = [start];
+  let prev = -1;
+  let cur = start;
+  for (let guard = 0; guard <= facets.length; guard++) {
+    const nbrs = adj.get(cur)!;
+    const next = nbrs[0] === prev ? nbrs[1] : nbrs[0];
+    if (next === undefined || next === start) break;
+    loop.push(next);
+    prev = cur;
+    cur = next;
+  }
+  // Orient counter-clockwise (positive signed area).
+  let signed = 0;
+  for (let i = 0; i < loop.length; i++) {
+    const p = points[loop[i]];
+    const q = points[loop[(i + 1) % loop.length]];
+    signed += p[0] * q[1] - q[0] * p[1];
+  }
+  if (signed < 0) loop.reverse();
+  loop.push(loop[0]); // close the polygon
+
+  const out = allocFloat64Array(loop.length);
+  for (let i = 0; i < loop.length; i++) out[i] = loop[i] + 1; // 1-based
+  return RTV.tensor(out, [loop.length, 1]); // column vector
+}
+
+defineBuiltin({
+  name: "convhull",
+  help: {
+    signatures: [
+      "k = convhull(P)",
+      "k = convhull(x,y)",
+      "k = convhull(x,y,z)",
+      "k = convhull(___,'Simplify',tf)",
+      "[k,av] = convhull(___)",
+    ],
+    description:
+      "Convex hull of a set of 2-D or 3-D points. With a single matrix P " +
+      "(N-by-2 or N-by-3), or coordinate vectors x,y (2-D) or x,y,z (3-D). " +
+      "For 2-D input, k is a column vector of 1-based point indices tracing " +
+      "the hull boundary counter-clockwise (closed: k(1)==k(end)). For 3-D " +
+      "input, k is a numFacets-by-3 matrix of triangle vertex indices. The " +
+      "second output av is the area (2-D) or volume (3-D). The 'Simplify' " +
+      "name-value pair is accepted for compatibility; the hull is always " +
+      "returned in minimal (simplified) form.",
+  },
+  cases: [
+    {
+      match: (argTypes, nargout) => {
+        if (nargout > 2) return null;
+        if (argTypes.length < 1 || argTypes.length > 5) return null;
+        const ok = (t: JitType) =>
+          t.kind === "number" ||
+          t.kind === "boolean" ||
+          t.kind === "tensor" ||
+          t.kind === "string" ||
+          t.kind === "char";
+        if (!argTypes.every(ok)) return null;
+        const k: JitType = { kind: "tensor", isComplex: false };
+        return nargout > 1 ? [k, { kind: "number" }] : [k];
+      },
+      apply: (args, nargout) => {
+        // Strip a trailing 'Simplify', tf name-value pair (accepted, ignored).
+        let coordArgs = args;
+        const tail = args[args.length - 2];
+        const isSimplifyName = (v: RuntimeValue) =>
+          (typeof v === "string" && v.toLowerCase() === "simplify") ||
+          (isRuntimeChar(v) && v.value.toLowerCase() === "simplify");
+        if (args.length >= 3 && isSimplifyName(tail)) {
+          coordArgs = args.slice(0, args.length - 2);
+        }
+
+        let points: number[][];
+        let dim: number;
+        if (coordArgs.length === 1) {
+          const P = coordArgs[0];
+          if (!isRuntimeTensor(P))
+            throw new RuntimeError(
+              "convhull: P must be an N-by-2 or N-by-3 matrix"
+            );
+          const [, d] = tensorSize2D(P);
+          if (d !== 2 && d !== 3)
+            throw new RuntimeError("convhull: P must have 2 or 3 columns");
+          points = matrixToPoints(P, "convhull");
+          dim = d;
+        } else if (coordArgs.length === 2 || coordArgs.length === 3) {
+          const coords = coordArgs.map(a => toFlatArray(a, "convhull"));
+          const n = coords[0].length;
+          if (coords.some(c => c.length !== n))
+            throw new RuntimeError(
+              "convhull: coordinate vectors must have the same length"
+            );
+          points = new Array(n);
+          for (let i = 0; i < n; i++) points[i] = coords.map(c => c[i]);
+          dim = coordArgs.length;
+        } else {
+          throw new RuntimeError("convhull: invalid arguments");
+        }
+
+        if (points.length < dim + 1)
+          throw new RuntimeError(
+            `convhull: need at least ${dim + 1} points for a ${dim}-D hull`
+          );
+
+        const facets = convexHullFacets(points, dim, "convhull");
+        const k =
+          dim === 2 ? orderHull2D(facets, points) : facetsToTensor(facets, 3);
+        if (nargout > 1) return [k, hullMeasure(points, facets, dim)];
+        return k;
+      },
+    },
+  ],
+});
+
+defineBuiltin({
+  name: "convhulln",
+  help: {
+    signatures: [
+      "k = convhulln(P)",
+      "k = convhulln(P,opts)",
+      "[k,vol] = convhulln(___)",
+    ],
+    description:
+      "N-D convex hull. P is an m-by-n matrix of m points in n-dimensional " +
+      "space. Returns a numFacets-by-n matrix where each row holds the 1-based " +
+      "point indices of one simplicial facet (edges for n=2, triangles for " +
+      "n=3). The second output is the area (n=2) or volume (n=3). The opts " +
+      "argument (Qhull options) is accepted for MATLAB compatibility but " +
+      "ignored. Note: only n = 2 and n = 3 are supported (see source comments).",
+  },
+  cases: [
+    {
+      match: (argTypes, nargout) => {
+        if (nargout > 2) return null;
+        if (argTypes.length < 1 || argTypes.length > 2) return null;
+        const x = argTypes[0];
+        if (x.kind !== "tensor" && x.kind !== "number" && x.kind !== "boolean")
+          return null;
+        const k: JitType = { kind: "tensor", isComplex: false };
+        return nargout > 1 ? [k, { kind: "number" }] : [k];
+      },
+      apply: (args, nargout) => {
+        const P = args[0];
+        if (!isRuntimeTensor(P))
+          throw new RuntimeError("convhulln: P must be an m-by-n matrix");
+        const [m, n] = tensorSize2D(P);
+        if (n < 2)
+          throw new RuntimeError("convhulln: P must have at least 2 columns");
+        if (n > CONVHULLN_MAX_DIM)
+          // Only n <= 3 is validated (parity with delaunayn).
+          throw new RuntimeError(
+            `convhulln: only 2-D and 3-D hulls are supported (got ${n}-D); ` +
+              `higher dimensions are not yet validated`
+          );
+        if (m < n + 1)
+          throw new RuntimeError(
+            `convhulln: need at least ${n + 1} points for a ${n}-D hull`
+          );
+        const points = matrixToPoints(P, "convhulln");
+        const facets = convexHullFacets(points, n, "convhulln");
+        const k = facetsToTensor(facets, n);
+        if (nargout > 1) return [k, hullMeasure(points, facets, n)];
+        return k;
       },
     },
   ],

--- a/src/numbl-core/native/geometry-bridge.ts
+++ b/src/numbl-core/native/geometry-bridge.ts
@@ -25,7 +25,15 @@
  */
 export type DelaunayBackend = (points: number[][], dim: number) => number[][];
 
+/**
+ * Compute the convex hull of `points` (an array of dim-dimensional tuples).
+ * Returns an array of simplicial facets, each a list of `dim` 0-based input
+ * point indices (edges in 2-D, triangles in 3-D).
+ */
+export type ConvexHullBackend = (points: number[][], dim: number) => number[][];
+
 let backend: DelaunayBackend | null = null;
+let hullBackend: ConvexHullBackend | null = null;
 
 /** Install (or clear, with null) the Delaunay backend. */
 export function setDelaunayBackend(fn: DelaunayBackend | null): void {
@@ -35,4 +43,14 @@ export function setDelaunayBackend(fn: DelaunayBackend | null): void {
 /** Get the current Delaunay backend, or null if none is installed. */
 export function getDelaunayBackend(): DelaunayBackend | null {
   return backend;
+}
+
+/** Install (or clear, with null) the convex-hull backend. */
+export function setConvexHullBackend(fn: ConvexHullBackend | null): void {
+  hullBackend = fn;
+}
+
+/** Get the current convex-hull backend, or null if none is installed. */
+export function getConvexHullBackend(): ConvexHullBackend | null {
+  return hullBackend;
 }

--- a/src/numbl-core/native/qhull-browser.ts
+++ b/src/numbl-core/native/qhull-browser.ts
@@ -12,7 +12,7 @@
  * installed and a later `delaunay`/`delaunayn` call throws (see geometry.ts).
  */
 
-import { setDelaunayBackend } from "./geometry-bridge.js";
+import { setDelaunayBackend, setConvexHullBackend } from "./geometry-bridge.js";
 import { loadQhull } from "qhull-wasm";
 import qhullWasmUrl from "qhull-wasm/dist/qhull.wasm?url";
 
@@ -30,9 +30,10 @@ async function load(): Promise<void> {
     const wasmBinary = new Uint8Array(await resp.arrayBuffer());
     const qhull = await loadQhull({ wasmBinary });
     setDelaunayBackend((points, dim) => qhull.delaunay(points, dim).facets);
+    setConvexHullBackend((points, dim) => qhull.convexHull(points, dim).facets);
   } catch (e) {
     console.error(
-      "qhull WASM backend failed to load; delaunay/delaunayn will be unavailable:",
+      "qhull WASM backend failed to load; delaunay/delaunayn/convhull/convhulln will be unavailable:",
       e instanceof Error ? e.message : String(e)
     );
   }

--- a/src/numbl-core/native/qhull-node.ts
+++ b/src/numbl-core/native/qhull-node.ts
@@ -10,7 +10,7 @@
  * Idempotent: the first call starts loading and caches the promise.
  */
 
-import { setDelaunayBackend } from "./geometry-bridge.js";
+import { setDelaunayBackend, setConvexHullBackend } from "./geometry-bridge.js";
 
 let promise: Promise<void> | null = null;
 
@@ -24,4 +24,5 @@ async function load(): Promise<void> {
   const { loadQhull } = await import("qhull-wasm");
   const qhull = await loadQhull();
   setDelaunayBackend((points, dim) => qhull.delaunay(points, dim).facets);
+  setConvexHullBackend((points, dim) => qhull.convexHull(points, dim).facets);
 }


### PR DESCRIPTION
Implements `convhull` and `convhulln`, backed by the existing qhull WASM module (the same engine behind `delaunay`/`delaunayn`).

- New convex-hull backend in `geometry-bridge.ts`, installed alongside the Delaunay backend by the Node and browser loaders.
- `convhull(P)`, `convhull(x,y)`, `convhull(x,y,z)`, `convhull(...,'Simplify',tf)`, `[k,av]=convhull(...)`.
  - 2-D: closed counter-clockwise boundary loop of point indices.
  - 3-D: `numFacets`-by-3 triangle matrix.
- `convhulln(P[,opts])`, `[k,vol]=convhulln(...)` — edge matrix (2-D) / triangle matrix (3-D). Validated for n=2,3 (parity with `delaunayn`).
- Area/volume (second output) computed exactly via fan decomposition from an interior point.
- qhull returns the minimal hull, matching MATLAB's `Simplify=true`; the `Simplify`/`opts` arguments are accepted for compatibility but do not change the result.

Verified against MATLAB's documented examples (2-D area 1.75; 3-D grid volume 64, 12 triangles). New tests in `src/__tests__/convhull.test.ts`.