### PR TITLE
Add MATLAB string arrays; fix parser/runtime gaps blocking meshio

### DIFF
--- a/docs/developer_reference/runtime/values-and-tensors.md
+++ b/docs/developer_reference/runtime/values-and-tensors.md
@@ -6,7 +6,8 @@ The runtime universe. A union of primitives plus refcounted classes:
 
 - `number` — JavaScript number (real scalar). Not refcounted.
 - `boolean` — logical scalar. Not refcounted.
-- `string` — MATLAB string (distinct from char). Not refcounted.
+- `string` — MATLAB string _scalar_ (distinct from char). Not refcounted.
+- `RuntimeStringArray` — MATLAB string array (`kind: "string_array"`): column-major `data: string[]` plus a 2-D `shape`. A 1×1 string is always represented as the primitive, never a 1×1 array — build results with `stringArrayValue(data, shape)`, which collapses 1×1 to the primitive (empties stay arrays, e.g. `string([])` is 0×0).
 - `RuntimeChar` — MATLAB char array.
 - `RuntimeTensor` — real or complex, any rank, any shape.
 - `RuntimeComplexNumber` — complex scalar.

--- a/numbl_test_scripts/arguments/test_varargin_then_options.m
+++ b/numbl_test_scripts/arguments/test_varargin_then_options.m
@@ -1,0 +1,38 @@
+% Test varargin followed by a name-value options parameter
+% (arguments blocks: Repeating varargin + options struct)
+
+[a, extras, s] = f(1, 2, 3);
+assert(a == 1);
+assert(isequal(extras, {2, 3}));
+assert(s == 1);
+
+[a, extras, s] = f(1, 2, 'scale', 10);
+assert(a == 1);
+assert(isequal(extras, {2}));
+assert(s == 10);
+
+[a, extras, s] = f(1, 'scale', 10);
+assert(a == 1);
+assert(isempty(extras));
+assert(s == 10);
+
+% Name=Value call syntax routes to the options struct too
+[a, extras, s] = f(1, 2, scale=7);
+assert(isequal(extras, {2}));
+assert(s == 7);
+
+disp('SUCCESS')
+
+function [a, extras, s] = f(a, varargin, opts)
+    arguments
+        a
+    end
+    arguments (Repeating)
+        varargin
+    end
+    arguments
+        opts.scale = 1
+    end
+    extras = varargin;
+    s = opts.scale;
+end

--- a/numbl_test_scripts/builtins/test_fscanf.m
+++ b/numbl_test_scripts/builtins/test_fscanf.m
@@ -1,0 +1,43 @@
+% Test fscanf: formatted matrix reads and text/position coherence with fgetl
+
+d = tempdir;
+fname = fullfile(d, 'numbl_fscanf_test.txt');
+fid = fopen(fname, 'w');
+fprintf(fid, 'header\n');
+fprintf(fid, '3\n');
+fprintf(fid, '1 10 100\n2 20 200\n3 30 300\n');
+fprintf(fid, 'footer\n');
+fclose(fid);
+
+% ftell reflects what fgetl consumed; fseek rewinds
+fid = fopen(fname, 'r');
+h = fgetl(fid);
+assert(strcmp(h, 'header'));
+assert(ftell(fid) == 7);
+fseek(fid, 0, 'bof');
+assert(strcmp(fgetl(fid), 'header'));
+
+% matrix read: fills column-major, so transpose recovers the rows
+n = sscanf(fgetl(fid), '%d');
+assert(n == 3);
+data = fscanf(fid, '%f', [3, n])';
+assert(isequal(size(data), [3 3]));
+assert(isequal(data, [1 10 100; 2 20 200; 3 30 300]));
+
+% fscanf stops right after the last matched value; fgetl picks up from there
+rest = fgetl(fid);
+assert(isempty(rest));
+foot = fgetl(fid);
+assert(strcmp(foot, 'footer'));
+fclose(fid);
+
+% scalar read with count output
+fid = fopen(fname, 'r');
+fgetl(fid);
+[val, cnt] = fscanf(fid, '%d', 1);
+assert(val == 3);
+assert(cnt == 1);
+fclose(fid);
+
+delete(fname);
+disp('SUCCESS')

--- a/numbl_test_scripts/classes/namevalue_method_call/NvOpts_.m
+++ b/numbl_test_scripts/classes/namevalue_method_call/NvOpts_.m
@@ -1,0 +1,27 @@
+classdef NvOpts_
+    properties
+        base = 1
+    end
+    methods
+        function obj = NvOpts_(b)
+            obj.base = b;
+        end
+        function r = scale(obj, x, opts)
+            arguments
+                obj
+                x
+                opts.factor = 1
+            end
+            r = obj.base * x * opts.factor;
+        end
+    end
+    methods (Static)
+        function r = combine(x, opts)
+            arguments
+                x
+                opts.offset = 0
+            end
+            r = x + opts.offset;
+        end
+    end
+end

--- a/numbl_test_scripts/classes/namevalue_method_call/namevalue_method_call.m
+++ b/numbl_test_scripts/classes/namevalue_method_call/namevalue_method_call.m
@@ -1,0 +1,21 @@
+% Test Name=Value syntax in method-call (dot) syntax: obj.method(x, name=value)
+
+obj = NvOpts_(2);
+
+% method call with name=value
+r = obj.scale(10, factor=3);
+assert(r == 2 * 10 * 3);
+
+% equivalent classic name-value pair
+r2 = obj.scale(10, 'factor', 4);
+assert(r2 == 2 * 10 * 4);
+
+% default when omitted
+r3 = obj.scale(10);
+assert(r3 == 2 * 10 * 1);
+
+% static method call with name=value
+r4 = NvOpts_.combine(5, offset=2);
+assert(r4 == 7);
+
+disp('SUCCESS')

--- a/numbl_test_scripts/classes/object_array_empty_grow/EmptyGrow_.m
+++ b/numbl_test_scripts/classes/object_array_empty_grow/EmptyGrow_.m
@@ -1,0 +1,12 @@
+classdef EmptyGrow_
+    properties
+        v = 0
+    end
+    methods
+        function obj = EmptyGrow_(x)
+            if nargin > 0
+                obj.v = x;
+            end
+        end
+    end
+end

--- a/numbl_test_scripts/classes/object_array_empty_grow/object_array_empty_grow.m
+++ b/numbl_test_scripts/classes/object_array_empty_grow/object_array_empty_grow.m
@@ -1,0 +1,28 @@
+% Test ClassName.empty, growing an object array with end+1, and reshape
+
+c = EmptyGrow_.empty(1, 0);
+assert(numel(c) == 0);
+assert(isempty(c));
+
+c(end+1) = EmptyGrow_(10);   % grow the empty array
+c(end+1) = EmptyGrow_(20);   % grow again (end on a single object)
+c(end+1) = EmptyGrow_(30);
+assert(numel(c) == 3);
+assert(c(1).v == 10);
+assert(c(2).v == 20);
+assert(c(3).v == 30);
+
+% reshape with an auto dimension
+r = reshape(c, 1, []);
+assert(isequal(size(r), [1 3]));
+assert(r(2).v == 20);
+
+col = reshape(c, [], 1);
+assert(isequal(size(col), [3 1]));
+assert(col(3).v == 30);
+
+% no-argument form is 0x0
+e = EmptyGrow_.empty;
+assert(numel(e) == 0);
+
+disp('SUCCESS')

--- a/numbl_test_scripts/strings/test_regexp_split.m
+++ b/numbl_test_scripts/strings/test_regexp_split.m
@@ -1,0 +1,24 @@
+% Test regexp 'split' output mode
+
+parts = regexp('2.2 0 8', '\s+', 'split');
+assert(iscell(parts));
+assert(numel(parts) == 3);
+assert(strcmp(parts{1}, '2.2'));
+assert(strcmp(parts{2}, '0'));
+assert(strcmp(parts{3}, '8'));
+
+% leading/trailing delimiters produce empty pieces
+p2 = regexp(',a,,b,', ',', 'split');
+assert(numel(p2) == 5);
+assert(isempty(p2{1}) && isempty(p2{3}) && isempty(p2{5}));
+assert(strcmp(p2{2}, 'a') && strcmp(p2{4}, 'b'));
+
+% no match: whole string in one piece
+p3 = regexp('abc', 'x', 'split');
+assert(numel(p3) == 1 && strcmp(p3{1}, 'abc'));
+
+% 'split' combined with 'once': split around the first match only
+p4 = regexp('a-b-c', '-', 'split', 'once');
+assert(numel(p4) == 2 && strcmp(p4{1}, 'a') && strcmp(p4{2}, 'b-c'));
+
+disp('SUCCESS')

--- a/numbl_test_scripts/strings/test_string_array_create.m
+++ b/numbl_test_scripts/strings/test_string_array_create.m
@@ -1,0 +1,68 @@
+% Test string array creation and shape queries
+
+% concatenating string scalars builds arrays
+s = ["a" "bb" "ccc"];
+assert(isstring(s));
+assert(strcmp(class(s), 'string'));
+assert(isequal(size(s), [1 3]));
+assert(numel(s) == 3);
+
+% 2-D construction
+str = ["Mercury" "Gemini" "Apollo"; "Skylab" "Skylab B" "ISS"];
+assert(isequal(size(str), [2 3]));
+assert(str(2, 2) == "Skylab B");
+
+% string([]) is a 0x0 empty string array; empties vanish in concatenation
+e = string([]);
+assert(isstring(e));
+assert(isempty(e));
+assert(isequal(size(e), [0 0]));
+out = [string([]), string('gmsh'), string('abc')];
+assert(isequal(size(out), [1 2]));
+assert(out(1) == "gmsh");
+
+% char operands become string elements (string wins over char)
+m = ["ab" 'cd'];
+assert(isstring(m));
+assert(numel(m) == 2);
+assert(m(2) == "cd");
+m2 = ['ab' "cd"];
+assert(numel(m2) == 2);
+
+% numbers and logicals convert elementwise
+x = ["a", 1.5, pi, true];
+assert(numel(x) == 4);
+assert(x(2) == "1.5");
+assert(x(3) == "3.1416");
+assert(x(4) == "true");
+
+% vertical concatenation
+v = ["a"; "b"; "c"];
+assert(isequal(size(v), [3 1]));
+assert(v(2) == "b");
+
+% transpose
+t = ["a" "b"]';
+assert(isequal(size(t), [2 1]));
+assert(t(2) == "b");
+
+% reshape (column-major order preserved)
+r = reshape(["a" "b" "c" "d"], 2, 2);
+assert(isequal(size(r), [2 2]));
+assert(r(2, 1) == "b");
+assert(r(1, 2) == "c");
+
+% a 1x1 result is a string scalar
+one = ["only"];
+assert(isequal(size(one), [1 1]));
+assert(one == "only");
+
+% strings() builder
+g = strings(2, 3);
+assert(isequal(size(g), [2 3]));
+assert(strlength(g(1, 1)) == 0);
+g0 = strings(0);
+assert(isempty(g0));
+assert(isstring(g0));
+
+disp('SUCCESS')

--- a/numbl_test_scripts/strings/test_string_array_fns.m
+++ b/numbl_test_scripts/strings/test_string_array_fns.m
@@ -1,0 +1,128 @@
+% Test string-array functions: split/join/unique/sort/cellstr/char/double/...
+
+% the MATLAB doc example: split and find unique words
+str = "A horse! A horse! My kingdom for a horse!";
+str = erase(str, "!");
+str = lower(str);
+str = split(str);
+assert(isstring(str));
+assert(isequal(size(str), [9 1]));
+assert(str(1) == "a" && str(2) == "horse");
+u = unique(str);
+assert(isequal(size(u), [5 1]));
+assert(u(1) == "a" && u(3) == "horse" && u(5) == "my");
+
+% split with a delimiter
+p = split("a,b,c", ",");
+assert(isequal(size(p), [3 1]));
+assert(p(2) == "b");
+
+% join
+j = join(["a" "b" "c"]);
+assert(isequal(size(j), [1 1]));
+assert(j == "a b c");
+j2 = join(["a" "b"], "-");
+assert(j2 == "a-b");
+
+% sort and unique keep vector orientation
+so = sort(["b" "a"]);
+assert(isequal(size(so), [1 2]));
+assert(so(1) == "a" && so(2) == "b");
+ur = unique(["b" "a" "b"]);
+assert(isequal(size(ur), [1 2]));
+assert(ur(1) == "a");
+
+% strjoin accepts string arrays and returns a string
+sj = strjoin(["a" "b"], ",");
+assert(isstring(sj));
+assert(sj == "a,b");
+
+% cellstr
+cs = cellstr(["a" "bb"]);
+assert(iscell(cs));
+assert(isequal(size(cs), [1 2]));
+assert(strcmp(cs{2}, 'bb'));
+
+% char of a string column pads rows
+ch = char(["ab"; "c"]);
+assert(ischar(ch));
+assert(isequal(size(ch), [2 2]));
+assert(strcmp(ch(1, :), 'ab'));
+assert(strcmp(ch(2, :), 'c '));
+
+% double parses text; str2double too
+d = double(["256" "3.1416" "8.9e-3"]);
+assert(abs(d(1) - 256) < 1e-12);
+assert(abs(d(2) - 3.1416) < 1e-12);
+assert(abs(d(3) - 0.0089) < 1e-12);
+dn = double(["1" "abc"]);
+assert(dn(1) == 1 && isnan(dn(2)));
+y = str2double(["2.5" "nope"]);
+assert(y(1) == 2.5 && isnan(y(2)));
+z = double("42");
+assert(z == 42);
+
+% strlength is elementwise
+sl = strlength(["ab" "c"]);
+assert(isequal(size(sl), [1 2]));
+assert(sl(1) == 2 && sl(2) == 1);
+
+% lower/upper/replace map elementwise and stay string arrays
+lo = lower(["AB" "Cd"]);
+assert(isstring(lo));
+assert(lo(1) == "ab" && lo(2) == "cd");
+rp = replace(["a-b" "c-d"], "-", "+");
+assert(rp(1) == "a+b" && rp(2) == "c+d");
+er = erase(["a-b" "c-d"], "-");
+assert(er(1) == "ab" && er(2) == "cd");
+
+% string() conversions
+sc = string({'a', 'bb'; 'c', 'dd'});
+assert(isstring(sc));
+assert(isequal(size(sc), [2 2]));
+assert(sc(2, 2) == "dd");
+scm = string(['ab'; 'cd']);
+assert(isequal(size(scm), [2 1]));
+assert(scm(2) == "cd");
+snm = string([1 2; 3 4]);
+assert(isequal(size(snm), [2 2]));
+assert(snm(2, 1) == "3");
+assert(string(pi) == "3.1416");
+assert(string(true) == "true");
+
+% strsplit on a string returns a string array
+ss = strsplit("a b");
+assert(isstring(ss));
+assert(numel(ss) == 2);
+assert(ss(2) == "b");
+
+% ismember
+im = ismember(["a" "z"], ["a" "b"]);
+assert(im(1) && ~im(2));
+
+% for iterates columns
+n = 0;
+for t = ["a" "b" "c"]
+    n = n + 1;
+    last = t;
+end
+assert(n == 3);
+assert(last == "c");
+n2 = 0;
+for t = ["a" "b"; "c" "d"]
+    n2 = n2 + 1;
+    sz = size(t);
+end
+assert(n2 == 2);
+assert(isequal(sz, [2 1]));
+
+% sprintf consumes string-array elements
+sp = sprintf('%s|', ["a" "b"]);
+assert(strcmp(sp, 'a|b|'));
+
+% ismissing on ordinary strings is all-false
+mm = ismissing(["a" ""]);
+assert(islogical(mm));
+assert(~mm(1) && ~mm(2));
+
+disp('SUCCESS')

--- a/numbl_test_scripts/strings/test_string_array_index.m
+++ b/numbl_test_scripts/strings/test_string_array_index.m
@@ -1,0 +1,80 @@
+% Test string array indexing, assignment, growth, and deletion
+
+arr = ["a" "b"; "c" "d"];
+
+% 2-D and linear reads
+assert(arr(2, 1) == "c");
+assert(arr(end) == "d");
+col2 = arr(:, 2);
+assert(isequal(size(col2), [2 1]));
+assert(col2(1) == "b" && col2(2) == "d");
+lin = arr([1 3]);
+assert(isequal(size(lin), [1 2]));
+assert(lin(2) == "b");
+msk = arr(logical([1 0; 0 1]));
+assert(isequal(size(msk), [2 1]));
+
+% brace extraction yields char
+s = ["one" "two" "three"];
+c = s{2};
+assert(ischar(c));
+assert(strcmp(c, 'two'));
+assert(s{2}(1) == 't');
+
+% scalar string braces
+sc = "abc";
+assert(ischar(sc{1}));
+assert(strcmp(sc{1}, 'abc'));
+assert(sc{1}(2) == 'b');
+assert(sc(end) == "abc");
+
+% element assignment
+la = ["a" "b" "c"];
+la(2) = "B";
+assert(la(2) == "B");
+la(logical([1 0 1])) = ["X" "Z"];
+assert(la(1) == "X" && la(2) == "B" && la(3) == "Z");
+
+% scalar expansion
+sa = ["a" "b" "c"];
+sa(2:3) = "z";
+assert(sa(2) == "z" && sa(3) == "z");
+
+% char RHS stays a string array
+h2 = ["a" "b"];
+h2(2) = 'c';
+assert(isstring(h2));
+assert(h2(2) == "c");
+
+% 2-D column assignment
+ca = ["a" "b"; "c" "d"];
+ca(:, 1) = ["p"; "q"];
+assert(ca(1, 1) == "p" && ca(2, 1) == "q");
+
+% growth from strings(0) — the accumulate pattern
+g = strings(0);
+g(end+1) = "x";
+g(end+1) = "y";
+assert(isequal(size(g), [1 2]));
+assert(g(1) == "x" && g(2) == "y");
+
+% growth from a scalar with a gap (values at the gap are unset)
+h = "a";
+h(4) = "d";
+assert(numel(h) == 4);
+assert(h(1) == "a" && h(4) == "d");
+
+% deletion
+dd = ["a" "b" "c"];
+dd(2) = [];
+assert(isequal(size(dd), [1 2]));
+assert(dd(1) == "a" && dd(2) == "c");
+
+% column vectors keep orientation
+cv = ["a"; "b"; "c"];
+cv(2) = [];
+assert(isequal(size(cv), [2 1]));
+cv(end+1) = "z";
+assert(isequal(size(cv), [3 1]));
+
+disp('SUCCESS')

--- a/numbl_test_scripts/strings/test_string_array_ops.m
+++ b/numbl_test_scripts/strings/test_string_array_ops.m
@@ -1,0 +1,64 @@
+% Test string array operators: ==, ~=, +, <, isequal
+
+% elementwise equality against a scalar
+eqr = ["a" "b"] == "a";
+assert(islogical(eqr));
+assert(isequal(size(eqr), [1 2]));
+assert(eqr(1) && ~eqr(2));
+ner = ["a" "b"] ~= "a";
+assert(~ner(1) && ner(2));
+
+% array vs array
+both = ["a" "b"] == ["a" "z"];
+assert(both(1) && ~both(2));
+
+% + appends elementwise
+pl = ["a" "b"] + "x";
+assert(isstring(pl));
+assert(pl(1) == "ax" && pl(2) == "bx");
+p2 = "pre" + ["a" "b"];
+assert(p2(1) == "prea" && p2(2) == "preb");
+p3 = ["a" "b"] + ["1" "2"];
+assert(p3(1) == "a1" && p3(2) == "b2");
+
+% + with a number appends its text form
+p4 = "abc" + 1;
+assert(isstring(p4));
+assert(p4 == "abc1");
+p5 = "ab" + 'c';
+assert(p5 == "abc");
+
+% lexicographic comparison
+assert("abc" < "abd");
+assert("b" > "a");
+
+% strcmp over arrays
+scr = strcmp(["a" "b"], "a");
+assert(isequal(size(scr), [1 2]));
+assert(scr(1) && ~scr(2));
+
+% contains / startsWith / endsWith over arrays
+cw = contains(["abc" "xyz"], "b");
+assert(islogical(cw));
+assert(cw(1) && ~cw(2));
+sw = startsWith(["abc" "xyz"], "a");
+assert(sw(1) && ~sw(2));
+ew = endsWith(["abc" "xyz"], "z");
+assert(~ew(1) && ew(2));
+
+% isequal
+assert(isequal(["a" "b"], ["a" "b"]));
+assert(~isequal(["a" "b"], ["a" "c"]));
+assert(~isequal(["a" "b"], ["a"; "b"]));
+assert(isequal("a", 'a'));
+
+% switch on string scalars still works
+x = "foo";
+hit = false;
+switch x
+    case "foo"
+        hit = true;
+end
+assert(hit);
+
+disp('SUCCESS')

--- a/numbl_test_scripts/strings/test_string_empty.m
+++ b/numbl_test_scripts/strings/test_string_empty.m
@@ -1,0 +1,12 @@
+% Test string([]) — an empty string value that concatenation treats as a no-op
+
+out = [string([]), string('gmsh')];
+assert(strcmp(class(out), 'string'));
+assert(out == "gmsh");
+
+% same pattern via a variable holding an empty double
+fmt = [];
+s = [string(fmt), "abc"];
+assert(s == "abc");
+
+disp('SUCCESS')

--- a/src/cli-fileio.ts
+++ b/src/cli-fileio.ts
@@ -168,12 +168,12 @@ export class NodeFileIOAdapter implements FileIOAdapter {
     // Buffer is empty and eof not yet detected — try reading to check
     const buf = Buffer.alloc(1);
     try {
-      const bytesRead = readSync(entry.fd, buf, 0, 1, null);
+      const bytesRead = readSync(entry.fd, buf, 0, 1, entry.pos);
       if (bytesRead === 0) {
         entry.eof = true;
         return 1;
       }
-      // Got data — put it back in the buffer
+      // Got data — put it back in the buffer (it starts at entry.pos)
       entry.buffer = buf.toString("utf-8", 0, bytesRead);
       return 0;
     } catch {
@@ -814,6 +814,12 @@ export class NodeFileIOAdapter implements FileIOAdapter {
 
   /**
    * Read one line from the file's buffer, refilling from the fd as needed.
+   *
+   * All reads are positional so `entry.pos` stays the single source of truth
+   * for the logical file position: the buffer always holds the bytes starting
+   * at `entry.pos`, and consuming a line advances `entry.pos` by its byte
+   * length. This keeps text I/O (fgetl/fgets) coherent with binary I/O and
+   * fscanf (freadBytes/fseek/ftell).
    * @param keepNewline - if true, keep the trailing newline (fgets); if false, strip it (fgetl)
    */
   private readLine(entry: OpenFile, keepNewline: boolean): string | number {
@@ -825,7 +831,13 @@ export class NodeFileIOAdapter implements FileIOAdapter {
       const buf = Buffer.alloc(READ_CHUNK_SIZE);
       let bytesRead: number;
       try {
-        bytesRead = readSync(entry.fd, buf, 0, READ_CHUNK_SIZE, null);
+        bytesRead = readSync(
+          entry.fd,
+          buf,
+          0,
+          READ_CHUNK_SIZE,
+          entry.pos + Buffer.byteLength(entry.buffer, "utf-8")
+        );
         entry.lastError = "";
       } catch (e) {
         entry.lastError = e instanceof Error ? e.message : String(e);
@@ -847,16 +859,17 @@ export class NodeFileIOAdapter implements FileIOAdapter {
     const nlIdx = entry.buffer.indexOf("\n");
     if (nlIdx !== -1) {
       // Found a newline
-      const line = keepNewline
-        ? entry.buffer.slice(0, nlIdx + 1)
-        : entry.buffer.slice(0, nlIdx);
+      const consumed = entry.buffer.slice(0, nlIdx + 1);
+      const line = keepNewline ? consumed : entry.buffer.slice(0, nlIdx);
       entry.buffer = entry.buffer.slice(nlIdx + 1);
+      entry.pos += Buffer.byteLength(consumed, "utf-8");
       return line;
     }
 
     // No newline found but we have data (EOF mid-line)
     const line = entry.buffer;
     entry.buffer = "";
+    entry.pos += Buffer.byteLength(line, "utf-8");
     return line;
   }
 }

--- a/src/numbl-core/helpers/arithmetic.ts
+++ b/src/numbl-core/helpers/arithmetic.ts
@@ -17,6 +17,9 @@ import {
   isRuntimeClassInstance,
   isRuntimeClassInstanceArray,
   RuntimeClassInstanceArray,
+  isRuntimeStringArray,
+  RuntimeStringArray,
+  stringArrayValue,
   kstr,
 } from "../runtime/types.js";
 import { RuntimeError } from "../runtime/error.js";
@@ -624,6 +627,29 @@ function coerceToConcatString(v: RuntimeValue): string | null {
 
 /** Add two RuntimeValues */
 export function mAdd(a: RuntimeValue, b: RuntimeValue): RuntimeValue {
+  // String-array `+` appends elementwise (broadcast scalar against array).
+  if (isRuntimeStringArray(a) || isRuntimeStringArray(b)) {
+    const sa = isRuntimeStringArray(a) ? a : null;
+    const sb = isRuntimeStringArray(b) ? b : null;
+    if (sa && sb) {
+      if (sa.shape[0] !== sb.shape[0] || sa.shape[1] !== sb.shape[1]) {
+        throw new RuntimeError("Array dimensions must match for string plus");
+      }
+      return stringArrayValue(
+        sa.data.map((s, i) => s + sb.data[i]),
+        sa.shape
+      );
+    }
+    const arr = (sa ?? sb)!;
+    const other = coerceToConcatString(sa ? b : a);
+    if (other === null) {
+      throw new RuntimeError("Cannot concatenate this value with a string");
+    }
+    return stringArrayValue(
+      arr.data.map(s => (sa ? s + other : other + s)),
+      arr.shape
+    );
+  }
   // MATLAB string `+` is concatenation, not numeric addition.  When
   // either operand is a string (and the other is convertible to text),
   // return a concatenated string.
@@ -1236,6 +1262,19 @@ function transposeClassInstanceArray(
   return new RuntimeClassInstanceArray(v.className, out, [c, r]);
 }
 
+/** Transpose a string array by permuting elements (strings have no
+ *  elementwise conjugate). */
+function transposeStringArray(v: RuntimeStringArray): RuntimeValue {
+  const [r, c] = v.shape;
+  const out: string[] = new Array(r * c);
+  for (let i = 0; i < r; i++) {
+    for (let j = 0; j < c; j++) {
+      out[i * c + j] = v.data[j * r + i];
+    }
+  }
+  return stringArrayValue(out, [c, r]);
+}
+
 /** Transpose (non-conjugate for complex scalars and tensors) */
 export function mTranspose(v: RuntimeValue): RuntimeValue {
   if (isRuntimeSparseMatrix(v)) return sparseTranspose(v);
@@ -1243,6 +1282,8 @@ export function mTranspose(v: RuntimeValue): RuntimeValue {
   if (isRuntimeNumber(v) || isRuntimeLogical(v)) return v;
   if (isRuntimeCell(v)) return transposeCellArray(v);
   if (isRuntimeChar(v)) return v;
+  if (isRuntimeString(v)) return v;
+  if (isRuntimeStringArray(v)) return transposeStringArray(v);
   // Object values without a class `transpose` method: MATLAB's built-in
   // array transpose permutes the elements. Reached only as the fallback
   // after method dispatch declines. A scalar instance is an identity.
@@ -1260,6 +1301,8 @@ export function mConjugateTranspose(v: RuntimeValue): RuntimeValue {
   if (isRuntimeNumber(v) || isRuntimeLogical(v)) return v;
   if (isRuntimeCell(v)) return transposeCellArray(v);
   if (isRuntimeChar(v)) return v;
+  if (isRuntimeString(v)) return v;
+  if (isRuntimeStringArray(v)) return transposeStringArray(v);
   // Object values without a class `ctranspose` method: the default array
   // operation rearranges elements (objects are not element-wise conjugated),
   // identical to mTranspose. A scalar instance is an identity.
@@ -1285,11 +1328,52 @@ function asStringPair(
   return null;
 }
 
+/** View a text operand as elements + shape for elementwise comparison
+ *  (string scalar / single-row char / string array). */
+function textOperandElems(
+  v: RuntimeValue
+): { data: string[]; shape: [number, number] } | null {
+  if (isRuntimeString(v)) return { data: [v], shape: [1, 1] };
+  if (isRuntimeChar(v)) {
+    const rows = v.shape ? v.shape[0] : 1;
+    if (rows > 1) return null;
+    return { data: [v.value], shape: [1, 1] };
+  }
+  if (isRuntimeStringArray(v)) return { data: v.data, shape: v.shape };
+  return null;
+}
+
 function stringComparisonOp(
   a: RuntimeValue,
   b: RuntimeValue,
   op: (x: string, y: string) => boolean
 ): RuntimeValue | null {
+  // Elementwise comparison when either side is a string array.
+  if (isRuntimeStringArray(a) || isRuntimeStringArray(b)) {
+    const ta = textOperandElems(a);
+    const tb = textOperandElems(b);
+    if (ta === null || tb === null) return null;
+    const aScalar = ta.data.length === 1 && ta.shape[0] * ta.shape[1] === 1;
+    const bScalar = tb.data.length === 1 && tb.shape[0] * tb.shape[1] === 1;
+    if (
+      !aScalar &&
+      !bScalar &&
+      (ta.shape[0] !== tb.shape[0] || ta.shape[1] !== tb.shape[1])
+    ) {
+      throw new RuntimeError("Array dimensions must match for comparison");
+    }
+    const shape = aScalar ? tb.shape : ta.shape;
+    const n = aScalar ? tb.data.length : ta.data.length;
+    const out = allocFloat64Array(n);
+    for (let i = 0; i < n; i++) {
+      const x = aScalar ? ta.data[0] : ta.data[i];
+      const y = bScalar ? tb.data[0] : tb.data[i];
+      out[i] = op(x, y) ? 1 : 0;
+    }
+    const t = RTV.tensor(out, [shape[0], shape[1]]);
+    t._isLogical = true;
+    return t;
+  }
   const pair = asStringPair(a, b);
   if (pair === null) return null;
   return RTV.logical(op(pair[0], pair[1]));

--- a/src/numbl-core/helpers/scanFormat.ts
+++ b/src/numbl-core/helpers/scanFormat.ts
@@ -1,0 +1,108 @@
+/**
+ * Shared scanning core for sscanf/fscanf: apply a MATLAB format string
+ * cyclically to input text, collecting numeric results.
+ */
+
+export interface ScanResult {
+  results: number[];
+  /** Number of characters consumed from the input. */
+  consumed: number;
+  matchFailure: boolean;
+}
+
+export function scanFormat(
+  str: string,
+  fmt: string,
+  maxCount: number
+): ScanResult {
+  const results: number[] = [];
+  let strPos = 0;
+  let fmtPos = 0;
+  let matchFailure = false;
+
+  while (
+    fmtPos < fmt.length &&
+    strPos < str.length &&
+    results.length < maxCount
+  ) {
+    if (fmt[fmtPos] === "%") {
+      fmtPos++;
+      if (fmtPos >= fmt.length) break;
+      // Skip width/precision modifiers, e.g. %10f or %5.2f
+      while (fmtPos < fmt.length && /[\d.]/.test(fmt[fmtPos])) fmtPos++;
+      if (fmtPos >= fmt.length) break;
+      const spec = fmt[fmtPos];
+      fmtPos++;
+      if (spec !== "c" && spec !== "s") {
+        while (strPos < str.length && /\s/.test(str[strPos])) strPos++;
+      }
+      if (spec === "d" || spec === "i" || spec === "u") {
+        const m = str.slice(strPos).match(/^[+-]?\d+/);
+        if (!m) {
+          matchFailure = true;
+          break;
+        }
+        results.push(parseInt(m[0], 10));
+        strPos += m[0].length;
+      } else if (spec === "f" || spec === "e" || spec === "g") {
+        const m = str
+          .slice(strPos)
+          .match(/^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?/);
+        if (!m) {
+          matchFailure = true;
+          break;
+        }
+        results.push(parseFloat(m[0]));
+        strPos += m[0].length;
+      } else if (spec === "x") {
+        const m = str.slice(strPos).match(/^[+-]?[0-9a-fA-F]+/);
+        if (!m) {
+          matchFailure = true;
+          break;
+        }
+        results.push(parseInt(m[0], 16));
+        strPos += m[0].length;
+      } else if (spec === "o") {
+        const m = str.slice(strPos).match(/^[+-]?[0-7]+/);
+        if (!m) {
+          matchFailure = true;
+          break;
+        }
+        results.push(parseInt(m[0], 8));
+        strPos += m[0].length;
+      } else if (spec === "c") {
+        results.push(str.charCodeAt(strPos));
+        strPos++;
+      } else if (spec === "s") {
+        const m = str.slice(strPos).match(/^\S+/);
+        if (!m) {
+          matchFailure = true;
+          break;
+        }
+        for (let ci = 0; ci < m[0].length && results.length < maxCount; ci++) {
+          results.push(m[0].charCodeAt(ci));
+        }
+        strPos += m[0].length;
+      }
+    } else if (/\s/.test(fmt[fmtPos])) {
+      fmtPos++;
+      while (strPos < str.length && /\s/.test(str[strPos])) strPos++;
+    } else {
+      if (str[strPos] !== fmt[fmtPos]) {
+        matchFailure = true;
+        break;
+      }
+      strPos++;
+      fmtPos++;
+    }
+    if (
+      fmtPos >= fmt.length &&
+      results.length < maxCount &&
+      strPos < str.length
+    ) {
+      fmtPos = 0;
+    }
+  }
+
+  return { results, consumed: strPos, matchFailure };
+}

--- a/src/numbl-core/interpreter/builtins/array-manipulation.ts
+++ b/src/numbl-core/interpreter/builtins/array-manipulation.ts
@@ -30,6 +30,9 @@ import {
   isRuntimeCell,
   isRuntimeClassInstance,
   isRuntimeClassInstanceArray,
+  isRuntimeString,
+  isRuntimeStringArray,
+  stringArrayValue,
 } from "../../runtime/types.js";
 import { defineBuiltin } from "./types.js";
 import type { JitType } from "../../jitTypes.js";
@@ -277,6 +280,47 @@ defineBuiltin({
             for (let i2 = 0; i2 < nr; i2++)
               chars[i2 * nc + j2] = linear[j2 * nr + i2];
           return new RuntimeChar(chars.join(""), [nr, nc]);
+        }
+
+        // String arrays: elements are stored column-major, so reshape only
+        // replaces the shape metadata.
+        if (isRuntimeStringArray(v)) {
+          const s = parseReshapeDims(args, v.data.length);
+          while (s.length > 2 && s[s.length - 1] === 1) s.pop();
+          if (s.length > 2)
+            throw new RuntimeError("reshape: string arrays must be 2-D");
+          const nr = s[0];
+          const nc = s.length >= 2 ? s[1] : 1;
+          return stringArrayValue(v.data.slice(), [nr, nc]);
+        }
+        if (isRuntimeString(v)) {
+          parseReshapeDims(args, 1); // validates the element count is 1
+          return v;
+        }
+
+        // Object arrays: elements are stored in linear order, so reshape
+        // only replaces the shape metadata.
+        if (isRuntimeClassInstanceArray(v)) {
+          const total = v.elements.length;
+          const s = parseReshapeDims(args, total);
+          while (s.length > 2 && s[s.length - 1] === 1) s.pop();
+          if (s.length > 2)
+            throw new RuntimeError("reshape: object arrays must be 2-D");
+          const nr = s[0];
+          const nc = s.length >= 2 ? s[1] : 1;
+          if (nr * nc !== total)
+            throw new RuntimeError(
+              "reshape: number of elements must not change"
+            );
+          return RTV.classInstanceArray(v.className, v.elements, [nr, nc]);
+        }
+        if (isRuntimeClassInstance(v)) {
+          const s = parseReshapeDims(args, 1);
+          if (s.reduce((a, b) => a * b, 1) !== 1)
+            throw new RuntimeError(
+              "reshape: number of elements must not change"
+            );
+          return v;
         }
 
         if (

--- a/src/numbl-core/interpreter/builtins/introspection.ts
+++ b/src/numbl-core/interpreter/builtins/introspection.ts
@@ -20,6 +20,7 @@ import {
   isRuntimeGraphicsHandle,
   isRuntimeDictionary,
   isRuntimeClassInstanceArray,
+  isRuntimeStringArray,
   RuntimeTensor,
 } from "../../runtime/types.js";
 import type { RuntimeValue } from "../../runtime/types.js";
@@ -58,6 +59,7 @@ function getShape(v: RuntimeValue): number[] {
   if (isRuntimeCell(v)) return v.shape;
   if (isRuntimeStructArray(v)) return [1, v.elements.length];
   if (isRuntimeClassInstanceArray(v)) return [...v.shape];
+  if (isRuntimeStringArray(v)) return [...v.shape];
   return [1, 1];
 }
 
@@ -123,7 +125,11 @@ defineBuiltin({
 
 defineBuiltin({
   name: "isstring",
-  cases: [anyToLogicalCase(args => isRuntimeString(args[0]))],
+  cases: [
+    anyToLogicalCase(
+      args => isRuntimeString(args[0]) || isRuntimeStringArray(args[0])
+    ),
+  ],
 });
 
 // MATLAB's reserved words (`iskeyword` with no args). Note true/false are
@@ -340,6 +346,7 @@ defineBuiltin({
       if (isRuntimeString(v)) return false;
       if (isRuntimeStructArray(v)) return v.elements.length === 0;
       if (isRuntimeClassInstanceArray(v)) return v.elements.length === 0;
+      if (isRuntimeStringArray(v)) return v.data.length === 0;
       return false;
     }),
   ],
@@ -401,6 +408,7 @@ defineBuiltin({
         if (isRuntimeString(v)) return 1;
         if (isRuntimeStructArray(v)) return v.elements.length;
         if (isRuntimeClassInstanceArray(v)) return v.elements.length;
+        if (isRuntimeStringArray(v)) return v.data.length;
         return 1;
       },
     },
@@ -433,6 +441,8 @@ defineBuiltin({
         if (isRuntimeStructArray(v)) return v.elements.length;
         if (isRuntimeClassInstanceArray(v))
           return v.elements.length === 0 ? 0 : Math.max(...v.shape);
+        if (isRuntimeStringArray(v))
+          return v.data.length === 0 ? 0 : Math.max(...v.shape);
         return 1;
       },
     },
@@ -572,6 +582,7 @@ defineBuiltin({
           return mkChar(v._isLogical ? "logical" : "double");
         if (isRuntimeSparseMatrix(v)) return mkChar("double");
         if (isRuntimeString(v)) return mkChar("string");
+        if (isRuntimeStringArray(v)) return mkChar("string");
         if (isRuntimeChar(v)) return mkChar("char");
         if (isRuntimeStruct(v) || isRuntimeStructArray(v))
           return mkChar("struct");

--- a/src/numbl-core/interpreter/builtins/set-operations.ts
+++ b/src/numbl-core/interpreter/builtins/set-operations.ts
@@ -16,6 +16,8 @@ import {
   isRuntimeSparseMatrix,
   isRuntimeString,
   isRuntimeTensor,
+  isRuntimeStringArray,
+  stringArrayValue,
 } from "../../runtime/types.js";
 import {
   RTV,
@@ -329,6 +331,10 @@ defineBuiltin({
           };
           return nargout > 1 ? [out, idx] : [out];
         }
+        if (a.kind === "string" || a.kind === "unknown") {
+          const out: JitType = { kind: "unknown" };
+          return nargout > 1 ? [out, { kind: "unknown" }] : [out];
+        }
         return null;
       },
       apply: (args, nargout) => {
@@ -350,6 +356,37 @@ defineBuiltin({
           (isRuntimeString(args[2]) || isRuntimeChar(args[2]))
         ) {
           descend = rstr(args[2]).toLowerCase() === "descend";
+        }
+
+        // Sort a string array's elements (vector orientation preserved).
+        if (isRuntimeStringArray(v)) {
+          const order = v.data.map((_, i) => i);
+          order.sort((i, j) => {
+            const x = v.data[i];
+            const y = v.data[j];
+            const c = x < y ? -1 : x > y ? 1 : 0;
+            return descend ? -c : c;
+          });
+          const sorted = order.map(i => v.data[i]);
+          const isRow = v.shape[0] === 1;
+          const shape: [number, number] = isRow
+            ? [1, sorted.length]
+            : [sorted.length, 1];
+          const result = stringArrayValue(sorted, shape);
+          if (nargout > 1) {
+            return [
+              result,
+              RTV.tensor(allocFloat64Array(order.map(i => i + 1)), [
+                shape[0],
+                shape[1],
+              ]),
+            ];
+          }
+          return result;
+        }
+        if (isRuntimeString(v)) {
+          if (nargout > 1) return [v, RTV.num(1)];
+          return v;
         }
 
         if (isRuntimeNumber(v)) {
@@ -777,8 +814,16 @@ const ismemberCases: BuiltinCase[] = [
     apply: (args, nargout) => {
       if (args.length < 2)
         throw new RuntimeError("ismember requires 2 arguments");
-      const v = args[0];
-      const b = args[1];
+      // String arrays run through the cellstr text path.
+      const asCellstr = (x: RuntimeValue): RuntimeValue =>
+        isRuntimeStringArray(x)
+          ? RTV.cell(
+              x.data.map(s => RTV.string(s)),
+              [x.shape[0], x.shape[1]]
+            )
+          : x;
+      const v = asCellstr(args[0]);
+      const b = asCellstr(args[1]);
 
       const isStringLike = (x: RuntimeValue) =>
         isRuntimeString(x) || isRuntimeChar(x);
@@ -1142,6 +1187,34 @@ defineBuiltin({
           )
         ) {
           return uniqueCellOfStrings(v, nargout, stable);
+        }
+
+        // String array: unique elements, preserving vector orientation.
+        if (isRuntimeStringArray(v)) {
+          const elems = v.data;
+          const seen = new Map<string, number>();
+          for (let i = 0; i < elems.length; i++) {
+            if (!seen.has(elems[i])) seen.set(elems[i], i);
+          }
+          let vals = [...seen.keys()];
+          if (!stable) vals = vals.sort();
+          const isRow = v.shape[0] === 1;
+          const shape: [number, number] = isRow
+            ? [1, vals.length]
+            : [vals.length, 1];
+          const result = stringArrayValue(vals, shape);
+          if (nargout <= 1) return result;
+          const ia = RTV.tensor(
+            allocFloat64Array(vals.map(s => seen.get(s)! + 1)),
+            [vals.length, 1]
+          );
+          if (nargout === 2) return [result, ia];
+          const pos = new Map(vals.map((s, i) => [s, i + 1]));
+          const ic = RTV.tensor(
+            allocFloat64Array(elems.map(s => pos.get(s)!)),
+            [elems.length, 1]
+          );
+          return [result, ia, ic];
         }
 
         if (!isRuntimeTensor(v))

--- a/src/numbl-core/interpreter/builtins/string-extras.ts
+++ b/src/numbl-core/interpreter/builtins/string-extras.ts
@@ -3,7 +3,12 @@
  * strsplit, strjoin, regexp, regexpi, regexprep, symvar.
  */
 
-import { isRuntimeCell } from "../../runtime/types.js";
+import {
+  isRuntimeCell,
+  isRuntimeString,
+  isRuntimeStringArray,
+  stringArrayValue,
+} from "../../runtime/types.js";
 import type { RuntimeValue } from "../../runtime/types.js";
 import { RTV, RuntimeError } from "../../runtime/index.js";
 import { toString } from "../../runtime/convert.js";
@@ -33,6 +38,8 @@ registerIBuiltin({
           let delims: string[];
           if (isRuntimeCell(args[1])) {
             delims = args[1].data.map(d => toString(d));
+          } else if (isRuntimeStringArray(args[1])) {
+            delims = args[1].data.slice();
           } else {
             delims = [toString(args[1])];
           }
@@ -41,8 +48,13 @@ registerIBuiltin({
             .join("|");
           parts = s.split(new RegExp("(?:" + escaped + ")+"));
         }
+        // MATLAB: string input yields a string array; char input a cellstr
+        // (cell of CHAR vectors, so downstream [a '/' b] concat stays char).
+        if (isRuntimeString(args[0]) || isRuntimeStringArray(args[0])) {
+          return stringArrayValue(parts, [1, parts.length]);
+        }
         return RTV.cell(
-          parts.map(p => RTV.string(p)),
+          parts.map(p => RTV.char(p)),
           [1, parts.length]
         );
       },
@@ -59,11 +71,18 @@ registerIBuiltin({
     return {
       outputTypes: [{ kind: "string" }],
       apply: args => {
-        if (!isRuntimeCell(args[0]))
+        let elements: string[];
+        if (isRuntimeCell(args[0])) {
+          elements = args[0].data.map(v => toString(v));
+        } else if (isRuntimeStringArray(args[0])) {
+          elements = args[0].data.slice();
+        } else if (isRuntimeString(args[0])) {
+          elements = [args[0]];
+        } else {
           throw new RuntimeError(
-            "strjoin: first argument must be a cell array"
+            "strjoin: first argument must be a cell array or string array"
           );
-        const elements = args[0].data.map(v => toString(v));
+        }
         const delim = args.length >= 2 ? toString(args[1]) : " ";
         return RTV.string(elements.join(delim));
       },
@@ -155,6 +174,20 @@ function regexpImpl(
           )
         ),
         [1, tokensList.length]
+      );
+    }
+    if (mode === "split") {
+      // Pieces of str between matches, including leading/trailing empties.
+      const splits: string[] = [];
+      let prev = 0;
+      for (let i = 0; i < starts.length; i++) {
+        splits.push(str.slice(prev, starts[i] - 1));
+        prev = ends[i];
+      }
+      splits.push(str.slice(prev));
+      return RTV.cell(
+        splits.map(s => RTV.char(s)),
+        [1, splits.length]
       );
     }
     if (mode === "names") {

--- a/src/numbl-core/interpreter/builtins/strings.ts
+++ b/src/numbl-core/interpreter/builtins/strings.ts
@@ -16,7 +16,10 @@ import {
   isRuntimeString,
   isRuntimeTensor,
   isRuntimeComplexNumber,
+  isRuntimeStringArray,
+  stringArrayValue,
 } from "../../runtime/types.js";
+import { ensureRuntimeValue } from "../../runtime/runtimeHelpers.js";
 import {
   RTV,
   toNumber,
@@ -27,6 +30,8 @@ import {
 import type { JitType } from "../../jitTypes.js";
 import { registerIBuiltin } from "./types.js";
 import { sprintfFormat } from "../../helpers/string.js";
+import { scanFormat } from "../../helpers/scanFormat.js";
+import { matlabNumToString } from "../../runtime/utils.js";
 import { allocFloat64Array } from "../../runtime/alloc.js";
 
 // ── Type helpers ──────────────────────────────────────────────────────
@@ -42,7 +47,8 @@ function preserveTextType(t: JitType): JitType | null {
   return null;
 }
 
-/** Apply a string function to a value, recursing into cells. */
+/** Apply a string function to a value, recursing into cells and mapping
+ *  element-wise over string arrays. */
 function applyTextFn(v: RuntimeValue, fn: (s: string) => string): RuntimeValue {
   if (isRuntimeCell(v)) {
     const out: RuntimeValue[] = new Array(v.data.length);
@@ -60,11 +66,14 @@ function applyTextFn(v: RuntimeValue, fn: (s: string) => string): RuntimeValue {
     return RTV.char(fn(v.value));
   }
   if (isRuntimeString(v)) return RTV.string(fn(toString(v)));
+  if (isRuntimeStringArray(v)) {
+    return RTV.stringArray(v.data.map(fn), [v.shape[0], v.shape[1]]);
+  }
   return v;
 }
 
 /** Resolve for a simple 1-arg text→text function that preserves char/string,
- *  and maps element-wise over cell arrays of text. */
+ *  and maps element-wise over cell arrays of text and string arrays. */
 function textPreserveResolve(fn: (s: string) => string): (
   argTypes: JitType[],
   nargout: number
@@ -79,6 +88,17 @@ function textPreserveResolve(fn: (s: string) => string): (
       return {
         outputTypes: [{ kind: "cell" }],
         apply: args => applyTextFn(args[0], fn),
+      };
+    }
+    // String arrays infer as "unknown" — accept and verify at runtime.
+    if (t.kind === "unknown") {
+      return {
+        outputTypes: [{ kind: "unknown" }],
+        apply: args => {
+          if (!isRuntimeStringArray(args[0]))
+            throw new RuntimeError("Expected a text input");
+          return applyTextFn(args[0], fn);
+        },
       };
     }
     const out = preserveTextType(t);
@@ -186,17 +206,17 @@ registerIBuiltin({
   name: "erase",
   resolve: argTypes => {
     if (argTypes.length !== 2) return null;
-    const out = preserveTextType(argTypes[0]);
+    const out =
+      argTypes[0].kind === "unknown"
+        ? { kind: "unknown" as const }
+        : preserveTextType(argTypes[0]);
     if (!out) return null;
     if (!isTextType(argTypes[1])) return null;
     return {
       outputTypes: [out],
       apply: args => {
-        const v = args[0];
-        const s = toString(v);
         const pat = toString(args[1]);
-        const result = s.split(pat).join("");
-        return isRuntimeChar(v) ? RTV.char(result) : RTV.string(result);
+        return applyTextFn(args[0], s => s.split(pat).join(""));
       },
     };
   },
@@ -213,18 +233,18 @@ function strreplaceResolve(): (
 } | null {
   return argTypes => {
     if (argTypes.length !== 3) return null;
-    const out = preserveTextType(argTypes[0]);
+    const out =
+      argTypes[0].kind === "unknown" || argTypes[0].kind === "cell"
+        ? ({ kind: argTypes[0].kind } as JitType)
+        : preserveTextType(argTypes[0]);
     if (!out) return null;
     if (!isTextType(argTypes[1]) || !isTextType(argTypes[2])) return null;
     return {
       outputTypes: [out],
       apply: args => {
-        const v = args[0];
-        const s = toString(v);
         const old = toString(args[1]);
         const rep = toString(args[2]);
-        const result = s.split(old).join(rep);
-        return isRuntimeChar(v) ? RTV.char(result) : RTV.string(result);
+        return applyTextFn(args[0], s => s.split(old).join(rep));
       },
     };
   };
@@ -441,12 +461,21 @@ function isText(v: RuntimeValue): boolean {
 }
 
 /** Element-wise strcmp helper supporting cell arrays. */
+/** View a string array as a cell of strings (for elementwise text ops). */
+function stringArrayToCell(v: RuntimeValue): RuntimeValue {
+  if (!isRuntimeStringArray(v)) return v;
+  return RTV.cell(
+    v.data.map(s => RTV.string(s)),
+    [v.shape[0], v.shape[1]]
+  );
+}
+
 function strcmpApply(
   args: RuntimeValue[],
   cmp: (a: string, b: string) => boolean
 ): RuntimeValue {
-  const a = args[0];
-  const b = args[1];
+  const a = stringArrayToCell(args[0]);
+  const b = stringArrayToCell(args[1]);
   const aIsCell = isRuntimeCell(a);
   const bIsCell = isRuntimeCell(b);
 
@@ -760,25 +789,53 @@ registerIBuiltin({
   },
 });
 
+/** Normalize a pattern argument (scalar text, cellstr, or string array) to a
+ *  list of pattern strings. */
+function patternList(pat: RuntimeValue): string[] {
+  if (isRuntimeCell(pat)) return pat.data.map(e => toString(e));
+  if (isRuntimeStringArray(pat)) return pat.data.slice();
+  return [toString(pat)];
+}
+
+/** Apply a per-element text predicate over a subject that may be scalar
+ *  text, a cellstr, or a string array. */
+function textSubjectApply(
+  subject: RuntimeValue,
+  perElem: (s: string) => boolean
+): RuntimeValue {
+  if (isRuntimeStringArray(subject)) {
+    return new RuntimeTensor(
+      allocFloat64Array(subject.data.map(s => (perElem(s) ? 1 : 0))),
+      [subject.shape[0], subject.shape[1]],
+      undefined,
+      true
+    );
+  }
+  if (isRuntimeCell(subject)) {
+    return new RuntimeTensor(
+      allocFloat64Array(subject.data.map(e => (perElem(toString(e)) ? 1 : 0))),
+      subject.shape.slice(),
+      undefined,
+      true
+    );
+  }
+  return RTV.logical(perElem(toString(subject)));
+}
+
+function subjectTypeOk(t: JitType): boolean {
+  return isTextType(t) || t.kind === "cell" || t.kind === "unknown";
+}
+
 registerIBuiltin({
   name: "contains",
   resolve: argTypes => {
     if (argTypes.length < 2) return null;
-    if (!isTextType(argTypes[0])) return null;
-    // Fall back for cell pattern arg
-    if (argTypes[1].kind === "unknown") return null;
+    if (!subjectTypeOk(argTypes[0])) return null;
     return {
       outputTypes: [{ kind: "boolean" }],
       apply: args => {
-        const s = toString(args[0]);
-        const pat = args[1];
-        if (isRuntimeCell(pat)) {
-          for (let i = 0; i < pat.data.length; i++) {
-            if (s.includes(toString(pat.data[i]))) return RTV.logical(true);
-          }
-          return RTV.logical(false);
-        }
-        return RTV.logical(s.includes(toString(pat)));
+        const pats = patternList(args[1]);
+        return textSubjectApply(args[0], s => pats.some(p => s.includes(p)));
       },
     };
   },
@@ -792,7 +849,7 @@ function resolveStartsEndsWith(
     name,
     resolve: argTypes => {
       if (argTypes.length < 2) return null;
-      if (!isTextType(argTypes[0])) return null;
+      if (!subjectTypeOk(argTypes[0])) return null;
       return {
         outputTypes: [{ kind: "boolean" }],
         apply: args => {
@@ -802,20 +859,12 @@ function resolveStartsEndsWith(
               ic = !!toNumber(args[i + 1]);
             }
           }
-          let s = toString(args[0]);
-          if (ic) s = s.toLowerCase();
-          const pat = args[1];
-          if (isRuntimeCell(pat)) {
-            for (let i = 0; i < pat.data.length; i++) {
-              let p = toString(pat.data[i]);
-              if (ic) p = p.toLowerCase();
-              if (testFn(s, p)) return RTV.logical(true);
-            }
-            return RTV.logical(false);
-          }
-          let p = toString(pat);
-          if (ic) p = p.toLowerCase();
-          return RTV.logical(testFn(s, p));
+          let pats = patternList(args[1]);
+          if (ic) pats = pats.map(p => p.toLowerCase());
+          return textSubjectApply(args[0], s0 => {
+            const s = ic ? s0.toLowerCase() : s0;
+            return pats.some(p => testFn(s, p));
+          });
         },
       };
     },
@@ -831,13 +880,19 @@ registerIBuiltin({
   name: "strlength",
   resolve: argTypes => {
     if (argTypes.length !== 1) return null;
-    if (!isTextType(argTypes[0])) return null;
+    if (!isTextType(argTypes[0]) && argTypes[0].kind !== "unknown") return null;
     return {
       outputTypes: [{ kind: "number", sign: "nonneg" }],
       apply: args => {
         const v = args[0];
         if (isRuntimeString(v)) return RTV.num(v.length);
         if (isRuntimeChar(v)) return RTV.num(v.value.length);
+        if (isRuntimeStringArray(v)) {
+          return RTV.tensor(allocFloat64Array(v.data.map(s => s.length)), [
+            v.shape[0],
+            v.shape[1],
+          ]);
+        }
         throw new RuntimeError("strlength: argument must be a string or char");
       },
     };
@@ -909,6 +964,20 @@ registerIBuiltin({
             }
           }
           return RTV.tensor(data, c.shape.slice());
+        },
+      };
+    }
+    if (t.kind === "unknown") {
+      return {
+        outputTypes: [{ kind: "tensor", isComplex: false }],
+        apply: args => {
+          const v = args[0];
+          if (!isRuntimeStringArray(v))
+            throw new RuntimeError("str2double: expected text input");
+          return RTV.tensor(
+            allocFloat64Array(v.data.map(s => str2doubleScalar(s))),
+            [v.shape[0], v.shape[1]]
+          );
         },
       };
     }
@@ -1120,29 +1189,7 @@ registerIBuiltin({
 
 // ── num2str ───────────────────────────────────────────────────────────
 
-function numStr(n: number): string {
-  if (n === Infinity) return "Inf";
-  if (n === -Infinity) return "-Inf";
-  if (isNaN(n)) return "NaN";
-  if (n === 0) return "0";
-  if (Number.isInteger(n)) return String(n);
-  const prec = 5;
-  const exp = Math.floor(Math.log10(Math.abs(n)));
-  let s: string;
-  if (exp < -4 || exp >= prec) {
-    s = n.toExponential(prec - 1);
-    const ePos = s.indexOf("e");
-    let mantissa = s.slice(0, ePos);
-    const expPart0 = s.slice(ePos);
-    if (mantissa.includes(".")) mantissa = mantissa.replace(/\.?0+$/, "");
-    const expPart = expPart0.replace(/([eE][+-])(\d)$/, "$1" + "0$2");
-    s = mantissa + expPart;
-  } else {
-    s = n.toPrecision(prec);
-    if (s.includes(".")) s = s.replace(/\.?0+$/, "");
-  }
-  return s;
-}
+const numStr = matlabNumToString;
 
 registerIBuiltin({
   name: "num2str",
@@ -1402,7 +1449,8 @@ registerIBuiltin({
       a.kind !== "string" &&
       a.kind !== "number" &&
       a.kind !== "tensor" &&
-      a.kind !== "cell"
+      a.kind !== "cell" &&
+      a.kind !== "unknown"
     )
       return null;
     return {
@@ -1428,6 +1476,11 @@ registerIBuiltin({
           for (const el of v.data) rows.push(...valueToCharRows(el));
           return charRowsToMatrix(rows);
         }
+        // char(stringArray): one row per element (column-major order),
+        // right-padded to the widest element.
+        if (isRuntimeStringArray(v)) {
+          return charRowsToMatrix(v.data.slice());
+        }
         throw new RuntimeError("char: unsupported arguments");
       },
     };
@@ -1439,14 +1492,301 @@ registerIBuiltin({
   resolve: argTypes => {
     if (argTypes.length !== 1) return null;
     const a = argTypes[0];
-    if (a.kind === "unknown") return null;
+    const scalarText =
+      a.kind === "char" ||
+      a.kind === "string" ||
+      a.kind === "number" ||
+      a.kind === "boolean";
     return {
-      outputTypes: [{ kind: "string" }],
+      outputTypes: [scalarText ? { kind: "string" } : { kind: "unknown" }],
       apply: args => {
+        const v = args[0];
+        if (isRuntimeString(v) || isRuntimeStringArray(v)) return v;
+        if (isRuntimeChar(v)) {
+          const rows = v.shape ? v.shape[0] : 1;
+          if (rows <= 1) return RTV.string(v.value);
+          // Char matrix: one string per row (m x 1), pad spaces preserved.
+          const width = v.shape![1];
+          const out: string[] = [];
+          for (let r = 0; r < rows; r++) {
+            out.push(v.value.slice(r * width, (r + 1) * width));
+          }
+          return RTV.stringArray(out, [rows, 1]);
+        }
+        if (isRuntimeNumber(v)) return RTV.string(numStr(v));
+        if (isRuntimeLogical(v)) return RTV.string(v ? "true" : "false");
+        if (isRuntimeTensor(v)) {
+          // Elementwise conversion, same shape ([] -> 0x0 empty string array).
+          const rows = v.shape.length >= 2 ? v.shape[0] : 1;
+          const cols =
+            v.data.length === 0
+              ? (v.shape[1] ?? 0)
+              : v.data.length / (rows || 1);
+          const out: string[] = [];
+          for (let i = 0; i < v.data.length; i++) {
+            out.push(
+              v._isLogical ? (v.data[i] ? "true" : "false") : numStr(v.data[i])
+            );
+          }
+          return stringArrayValue(out, [rows, cols]);
+        }
+        if (isRuntimeCell(v)) {
+          const rows = v.shape.length >= 2 ? v.shape[0] : 1;
+          const cols = v.data.length / (rows || 1);
+          const out = v.data.map(el => {
+            const rv = ensureRuntimeValue(el);
+            if (isRuntimeChar(rv)) return rv.value;
+            if (isRuntimeString(rv)) return rv;
+            if (isRuntimeNumber(rv)) return numStr(rv);
+            if (isRuntimeLogical(rv)) return rv ? "true" : "false";
+            throw new RuntimeError(
+              "string: cell elements must be text or numbers"
+            );
+          });
+          return stringArrayValue(out, [rows, cols]);
+        }
+        return RTV.string(displayValue(v));
+      },
+    };
+  },
+});
+
+registerIBuiltin({
+  name: "strings",
+  help: {
+    signatures: ["strings", "strings(n)", "strings(m,n)", "strings([m n])"],
+    description:
+      'Create a string array with every element set to "" (empty string).',
+  },
+  resolve: argTypes => {
+    if (argTypes.some(t => t.kind !== "number" && t.kind !== "tensor"))
+      return null;
+    return {
+      outputTypes: [{ kind: "unknown" }],
+      apply: args => {
+        const dims: number[] = [];
+        for (const a of args) {
+          const rv = ensureRuntimeValue(a);
+          if (isRuntimeTensor(rv)) {
+            for (const d of rv.data) dims.push(Math.max(0, Math.round(d)));
+          } else {
+            dims.push(Math.max(0, Math.round(toNumber(rv))));
+          }
+        }
+        if (dims.length === 0) dims.push(1, 1);
+        if (dims.length === 1) dims.push(dims[0]);
+        const m = dims[0];
+        const n = dims.slice(1).reduce((a, b) => a * b, 1);
+        return stringArrayValue(new Array<string>(m * n).fill(""), [m, n]);
+      },
+    };
+  },
+});
+
+registerIBuiltin({
+  name: "newline",
+  help: {
+    signatures: ["newline"],
+    description: "Newline character, char(10).",
+  },
+  resolve: argTypes => {
+    if (argTypes.length !== 0) return null;
+    return {
+      outputTypes: [{ kind: "char" }],
+      apply: () => RTV.char("\n"),
+    };
+  },
+});
+
+// ── split / join (string arrays) ──────────────────────────────────────
+
+registerIBuiltin({
+  name: "split",
+  help: {
+    signatures: ["split(str)", "split(str, delimiter)"],
+    description:
+      "Split text at whitespace (or the given delimiter(s)) into a string array. " +
+      "A scalar input yields a column of parts.",
+  },
+  resolve: argTypes => {
+    if (argTypes.length < 1 || argTypes.length > 2) return null;
+    const a = argTypes[0];
+    if (!isTextType(a) && a.kind !== "cell" && a.kind !== "unknown")
+      return null;
+    return {
+      outputTypes: [{ kind: "unknown" }],
+      apply: args => {
+        const delims = args.length >= 2 ? patternList(args[1]) : null;
+        const splitOne = (s: string): string[] => {
+          if (delims === null) {
+            const trimmed = s.trim();
+            return trimmed.length === 0 ? [""] : trimmed.split(/\s+/);
+          }
+          const escaped = delims
+            .map(d => d.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+            .join("|");
+          return s.split(new RegExp(escaped));
+        };
+        const v = args[0];
+        const subjects: string[] = isRuntimeStringArray(v)
+          ? v.data.slice()
+          : isRuntimeCell(v)
+            ? v.data.map(e => toString(e))
+            : [toString(v)];
+        const partsPer = subjects.map(splitOne);
+        const nParts = partsPer[0].length;
+        if (partsPer.some(p => p.length !== nParts)) {
+          throw new RuntimeError(
+            "split: all elements must split into the same number of parts"
+          );
+        }
+        if (subjects.length === 1) {
+          return stringArrayValue(partsPer[0], [nParts, 1]);
+        }
+        // Vector input of m elements -> m x nParts (column-major storage).
+        const m = subjects.length;
+        const out: string[] = new Array(m * nParts);
+        for (let i = 0; i < m; i++) {
+          for (let j = 0; j < nParts; j++) {
+            out[j * m + i] = partsPer[i][j];
+          }
+        }
+        return stringArrayValue(out, [m, nParts]);
+      },
+    };
+  },
+});
+
+registerIBuiltin({
+  name: "join",
+  help: {
+    signatures: ["join(str)", "join(str, delimiter)"],
+    description:
+      "Combine the elements of a string array into single strings, " +
+      "separated by a space (or the given delimiter).",
+  },
+  resolve: argTypes => {
+    if (argTypes.length < 1 || argTypes.length > 2) return null;
+    const a = argTypes[0];
+    if (!isTextType(a) && a.kind !== "cell" && a.kind !== "unknown")
+      return null;
+    return {
+      outputTypes: [{ kind: "unknown" }],
+      apply: args => {
+        const delim = args.length >= 2 ? toString(args[1]) : " ";
         const v = args[0];
         if (isRuntimeString(v)) return v;
         if (isRuntimeChar(v)) return RTV.string(v.value);
-        return RTV.string(displayValue(v));
+        const elems: string[] = isRuntimeStringArray(v)
+          ? v.data
+          : isRuntimeCell(v)
+            ? v.data.map(e => toString(e))
+            : [toString(v)];
+        const shape: [number, number] = isRuntimeStringArray(v)
+          ? v.shape
+          : [1, elems.length];
+        const [m, n] = shape;
+        if (m === 1 || n === 1) {
+          return RTV.string(elems.join(delim));
+        }
+        // Matrix: join along dim 2 -> m x 1 column.
+        const out: string[] = [];
+        for (let r = 0; r < m; r++) {
+          const parts: string[] = [];
+          for (let c = 0; c < n; c++) parts.push(elems[c * m + r]);
+          out.push(parts.join(delim));
+        }
+        return stringArrayValue(out, [m, 1]);
+      },
+    };
+  },
+});
+
+registerIBuiltin({
+  name: "cellstr",
+  help: {
+    signatures: ["cellstr(A)"],
+    description:
+      "Convert a string array, char array, or cell array of text to a " +
+      "cell array of character vectors.",
+  },
+  resolve: argTypes => {
+    if (argTypes.length !== 1) return null;
+    const a = argTypes[0];
+    if (!isTextType(a) && a.kind !== "cell" && a.kind !== "unknown")
+      return null;
+    return {
+      outputTypes: [{ kind: "cell" }],
+      apply: args => {
+        const v = args[0];
+        if (isRuntimeCell(v)) {
+          return RTV.cell(
+            v.data.map(e => RTV.char(toString(e))),
+            [...v.shape]
+          );
+        }
+        if (isRuntimeStringArray(v)) {
+          return RTV.cell(
+            v.data.map(s => RTV.char(s)),
+            [v.shape[0], v.shape[1]]
+          );
+        }
+        if (isRuntimeString(v)) return RTV.cell([RTV.char(v)], [1, 1]);
+        if (isRuntimeChar(v)) {
+          const rows = v.shape ? v.shape[0] : 1;
+          if (rows <= 1) {
+            // MATLAB deblanks each row when converting char to cellstr.
+            return RTV.cell([RTV.char(v.value.replace(/\s+$/, ""))], [1, 1]);
+          }
+          const width = v.shape![1];
+          const out: RuntimeValue[] = [];
+          for (let r = 0; r < rows; r++) {
+            out.push(
+              RTV.char(
+                v.value.slice(r * width, (r + 1) * width).replace(/\s+$/, "")
+              )
+            );
+          }
+          return RTV.cell(out, [rows, 1]);
+        }
+        throw new RuntimeError("cellstr: unsupported argument");
+      },
+    };
+  },
+});
+
+registerIBuiltin({
+  name: "ismissing",
+  help: {
+    signatures: ["ismissing(A)"],
+    description:
+      "Logical array marking missing elements. numbl has no <missing> " +
+      "value, so string inputs return all-false.",
+  },
+  resolve: argTypes => {
+    if (argTypes.length !== 1) return null;
+    return {
+      outputTypes: [{ kind: "boolean" }],
+      apply: args => {
+        const v = args[0];
+        if (isRuntimeStringArray(v)) {
+          const t = RTV.tensor(allocFloat64Array(v.data.length), [
+            v.shape[0],
+            v.shape[1],
+          ]);
+          t._isLogical = true;
+          return t;
+        }
+        if (isRuntimeTensor(v)) {
+          const t = RTV.tensor(
+            allocFloat64Array(v.data.map(x => (isNaN(x) ? 1 : 0))),
+            [...v.shape]
+          );
+          t._isLogical = true;
+          return t;
+        }
+        if (isRuntimeNumber(v)) return RTV.logical(isNaN(v));
+        return RTV.logical(false);
       },
     };
   },
@@ -1493,7 +1833,14 @@ registerIBuiltin({
       outputTypes: [outType],
       apply: args => {
         const fmt = toString(args[0]);
-        const result = sprintfFormat(fmt, args.slice(1));
+        // A string-array argument supplies one text arg per element
+        // (the format cycles over them, like numeric arrays).
+        const rest = args
+          .slice(1)
+          .flatMap(a =>
+            isRuntimeStringArray(a) ? a.data.map(s => RTV.string(s)) : [a]
+          );
+        const result = sprintfFormat(fmt, rest);
         return isChar ? RTV.char(result) : RTV.string(result);
       },
     };
@@ -1517,95 +1864,11 @@ registerIBuiltin({
         const str = toString(args[0]);
         const fmt = toString(args[1]);
         const maxCount = args.length >= 3 ? toNumber(args[2]) : Infinity;
-        const results: number[] = [];
-        let strPos = 0;
-        let fmtPos = 0;
-        let matchFailure = false;
-
-        while (
-          fmtPos < fmt.length &&
-          strPos < str.length &&
-          results.length < maxCount
-        ) {
-          if (fmt[fmtPos] === "%") {
-            fmtPos++;
-            if (fmtPos >= fmt.length) break;
-            const spec = fmt[fmtPos];
-            fmtPos++;
-            if (spec !== "c" && spec !== "s") {
-              while (strPos < str.length && /\s/.test(str[strPos])) strPos++;
-            }
-            if (spec === "d" || spec === "i") {
-              const m = str.slice(strPos).match(/^[+-]?\d+/);
-              if (!m) {
-                matchFailure = true;
-                break;
-              }
-              results.push(parseInt(m[0], 10));
-              strPos += m[0].length;
-            } else if (spec === "f" || spec === "e" || spec === "g") {
-              const m = str
-                .slice(strPos)
-                .match(/^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?/);
-              if (!m) {
-                matchFailure = true;
-                break;
-              }
-              results.push(parseFloat(m[0]));
-              strPos += m[0].length;
-            } else if (spec === "x") {
-              const m = str.slice(strPos).match(/^[+-]?[0-9a-fA-F]+/);
-              if (!m) {
-                matchFailure = true;
-                break;
-              }
-              results.push(parseInt(m[0], 16));
-              strPos += m[0].length;
-            } else if (spec === "o") {
-              const m = str.slice(strPos).match(/^[+-]?[0-7]+/);
-              if (!m) {
-                matchFailure = true;
-                break;
-              }
-              results.push(parseInt(m[0], 8));
-              strPos += m[0].length;
-            } else if (spec === "c") {
-              results.push(str.charCodeAt(strPos));
-              strPos++;
-            } else if (spec === "s") {
-              const m = str.slice(strPos).match(/^\S+/);
-              if (!m) {
-                matchFailure = true;
-                break;
-              }
-              for (
-                let ci = 0;
-                ci < m[0].length && results.length < maxCount;
-                ci++
-              ) {
-                results.push(m[0].charCodeAt(ci));
-              }
-              strPos += m[0].length;
-            }
-          } else if (/\s/.test(fmt[fmtPos])) {
-            fmtPos++;
-            while (strPos < str.length && /\s/.test(str[strPos])) strPos++;
-          } else {
-            if (str[strPos] !== fmt[fmtPos]) {
-              matchFailure = true;
-              break;
-            }
-            strPos++;
-            fmtPos++;
-          }
-          if (
-            fmtPos >= fmt.length &&
-            results.length < maxCount &&
-            strPos < str.length
-          ) {
-            fmtPos = 0;
-          }
-        }
+        const {
+          results,
+          consumed: strPos,
+          matchFailure,
+        } = scanFormat(str, fmt, maxCount);
 
         const vals =
           results.length === 1

--- a/src/numbl-core/interpreter/builtins/type-constructors.ts
+++ b/src/numbl-core/interpreter/builtins/type-constructors.ts
@@ -16,6 +16,7 @@ import {
   isRuntimeStructArray,
   isRuntimeSparseMatrix,
   isRuntimeFunction,
+  isRuntimeStringArray,
   RuntimeTensor,
 } from "../../runtime/types.js";
 import type {
@@ -32,6 +33,15 @@ import { imagAllZero } from "../../helpers/effectively-real.js";
 
 // ── double ──────────────────────────────────────────────────────────────
 
+/** Parse string text to a double (MATLAB double(string) semantics):
+ *  numeric text parses, anything else is NaN. */
+function parseDoubleText(s: string): number {
+  const t = s.trim();
+  if (t === "") return NaN;
+  if (/^[+-]?inf(inity)?$/i.test(t)) return t[0] === "-" ? -Infinity : Infinity;
+  return Number(t);
+}
+
 defineBuiltin({
   name: "double",
   cases: [
@@ -43,6 +53,8 @@ defineBuiltin({
           a.kind === "number" ||
           a.kind === "boolean" ||
           a.kind === "char" ||
+          a.kind === "string" ||
+          a.kind === "unknown" ||
           a.kind === "complex_or_number" ||
           a.kind === "class_instance"
         )
@@ -66,6 +78,15 @@ defineBuiltin({
           if (v.value.length === 1) return RTV.num(v.value.charCodeAt(0));
           const codes = Array.from(v.value).map(c => c.charCodeAt(0));
           return RTV.row(codes);
+        }
+        // Strings convert by PARSING the text (unlike char code points);
+        // non-numeric text becomes NaN.
+        if (isRuntimeString(v)) return RTV.num(parseDoubleText(v));
+        if (isRuntimeStringArray(v)) {
+          return RTV.tensor(allocFloat64Array(v.data.map(parseDoubleText)), [
+            v.shape[0],
+            v.shape[1],
+          ]);
         }
         if (isRuntimeLogical(v)) return RTV.num(v ? 1 : 0);
         if (isRuntimeNumber(v)) return v;

--- a/src/numbl-core/interpreter/builtins/utility.ts
+++ b/src/numbl-core/interpreter/builtins/utility.ts
@@ -13,6 +13,7 @@ import {
   isRuntimeStruct,
   isRuntimeStructArray,
   isRuntimeSparseMatrix,
+  isRuntimeStringArray,
 } from "../../runtime/types.js";
 import type {
   RuntimeValue,
@@ -97,6 +98,13 @@ function valuesEqualSimple(a: RuntimeValue, b: RuntimeValue): boolean {
     for (const [key, val] of a.fields) {
       if (!b.fields.has(key)) return false;
       if (!valuesEqualSimple(val, b.fields.get(key)!)) return false;
+    }
+    return true;
+  }
+  if (isRuntimeStringArray(a) && isRuntimeStringArray(b)) {
+    if (a.shape[0] !== b.shape[0] || a.shape[1] !== b.shape[1]) return false;
+    for (let i = 0; i < a.data.length; i++) {
+      if (a.data[i] !== b.data[i]) return false;
     }
     return true;
   }

--- a/src/numbl-core/interpreter/builtins/validation.ts
+++ b/src/numbl-core/interpreter/builtins/validation.ts
@@ -248,6 +248,8 @@ function getValClassName(v: RuntimeValue): string {
       return "double";
     case "dictionary":
       return "dictionary";
+    case "string_array":
+      return "string";
     default:
       return "unknown";
   }
@@ -281,6 +283,8 @@ function getShapeOf(v: RuntimeValue): number[] {
       return [1, 1];
     case "struct_array":
       return [1, (obj.elements as unknown[]).length];
+    case "string_array":
+      return [...(obj.shape as number[])];
     default:
       return [1, 1];
   }

--- a/src/numbl-core/interpreter/interpreterExec.ts
+++ b/src/numbl-core/interpreter/interpreterExec.ts
@@ -16,6 +16,7 @@ import {
   isRuntimeFunction,
   isRuntimeStructArray,
   isRuntimeSparseMatrix,
+  isRuntimeStringArray,
 } from "../runtime/types.js";
 import { RTV, getItemTypeFromRuntimeValue } from "../runtime/constructors.js";
 import { ensureRuntimeValue } from "../runtime/runtimeHelpers.js";
@@ -532,14 +533,20 @@ export function evalExprNargout(
           return ctx.dimIndex < rv.shape.length ? rv.shape[ctx.dimIndex] : 1;
         }
         if (isRuntimeChar(rv)) return rv.value.length;
-        if (isRuntimeString(rv)) return (rv as string).length;
-        // Class instances: call overloaded end(obj, k, n) if available
+        // A string scalar is a 1x1 array: end is 1 (s(end) is s itself).
+        if (isRuntimeString(rv)) return 1;
+        // Class instances: call overloaded end(obj, k, n) if available;
+        // otherwise default to 1 (a scalar instance has extent 1 in every
+        // dimension, matching MATLAB's builtin end).
         if (isRuntimeClassInstance(rv)) {
-          return this.rt.dispatch("end", 1, [
-            rv,
-            ctx.dimIndex + 1,
-            ctx.numIndices,
-          ]);
+          if (this.rt.resolveClassMethod?.(rv.className, "end")) {
+            return this.rt.dispatch("end", 1, [
+              rv,
+              ctx.dimIndex + 1,
+              ctx.numIndices,
+            ]);
+          }
+          return 1;
         }
         if (isRuntimeStructArray(rv)) {
           return rv.elements.length;
@@ -547,6 +554,10 @@ export function evalExprNargout(
         if (isRuntimeClassInstanceArray(rv)) {
           if (ctx.numIndices === 1) return rv.elements.length;
           return ctx.dimIndex < rv.shape.length ? rv.shape[ctx.dimIndex] : 1;
+        }
+        if (isRuntimeStringArray(rv)) {
+          if (ctx.numIndices === 1) return rv.data.length;
+          return ctx.dimIndex < 2 ? rv.shape[ctx.dimIndex] : 1;
         }
         if (isRuntimeSparseMatrix(rv)) {
           if (ctx.numIndices === 1) return rv.m * rv.n;
@@ -1011,7 +1022,10 @@ export function evalMember(
         const prefix = dottedName.slice(0, lastDot);
         const methodName = dottedName.slice(lastDot + 1);
         if (
-          this.functionIndex.classStaticMethods.get(prefix)?.has(methodName)
+          this.functionIndex.classStaticMethods.get(prefix)?.has(methodName) ||
+          // Implicit static `ClassName.empty` (handled by interpretClassMethod)
+          (methodName === "empty" &&
+            this.functionIndex.workspaceClasses.has(prefix))
         ) {
           const target: ResolvedTarget = {
             kind: "classMethod",

--- a/src/numbl-core/interpreter/interpreterFunctions.ts
+++ b/src/numbl-core/interpreter/interpreterFunctions.ts
@@ -5,13 +5,18 @@
 
 import type { Expr } from "../parser/types.js";
 import type { RuntimeValue } from "../runtime/types.js";
-import { isRuntimeCell } from "../runtime/types.js";
+import {
+  isRuntimeCell,
+  isRuntimeChar,
+  isRuntimeString,
+  isRuntimeTensor,
+} from "../runtime/types.js";
 import { RTV, getItemTypeFromRuntimeValue } from "../runtime/constructors.js";
 import { ensureRuntimeValue } from "../runtime/runtimeHelpers.js";
 import type { CallSite } from "../runtime/runtimeHelpers.js";
 import { RuntimeError } from "../runtime/error.js";
 import { getIBuiltin, inferJitType } from "./builtins/index.js";
-import { toString } from "../runtime/convert.js";
+import { toString, toNumber } from "../runtime/convert.js";
 import { resolveFunction, type ResolvedTarget } from "../functionResolve.js";
 import type { ClassInfo } from "../lowering/classInfo.js";
 import {
@@ -489,6 +494,24 @@ export function interpretClassMethod(
         () => this.callUserFunction(extFn, actualArgs, nargout)
       );
     }
+    // Implicit static `ClassName.empty(m,n)`: every MATLAB class inherits
+    // an `empty` method producing an empty object array.
+    if (methodName === "empty") {
+      const dims: number[] = [];
+      for (const a of args) {
+        const rv = ensureRuntimeValue(a);
+        if (isRuntimeTensor(rv)) for (const d of rv.data) dims.push(d);
+        else dims.push(toNumber(rv));
+      }
+      if (dims.length === 1) dims.push(dims[0]);
+      if (dims.length === 0) dims.push(0, 0);
+      if (!dims.some(d => d === 0)) {
+        throw new RuntimeError(
+          `${className}.empty: at least one dimension must be zero`
+        );
+      }
+      return RTV.classInstanceArray(className, [], [dims[0], dims[1]]);
+    }
     throw new RuntimeError(
       `No method '${methodName}' for class '${className}'`
     );
@@ -686,9 +709,13 @@ export function callUserFunction(
   fnEnv.rt = this.rt;
   fnEnv.persistentFuncId = `${this.currentFile}:${fn.name}`;
 
-  const hasVarargin =
-    fn.params.length > 0 && fn.params[fn.params.length - 1] === "varargin";
-  const regularParams = hasVarargin ? fn.params.slice(0, -1) : fn.params;
+  // `varargin` is normally last, but name-value struct parameters declared
+  // via dotted `arguments` entries may follow it (the parser enforces this).
+  const vararginIdx = fn.params.indexOf("varargin");
+  const hasVarargin = vararginIdx !== -1;
+  const regularParams = hasVarargin
+    ? fn.params.slice(0, vararginIdx)
+    : fn.params;
 
   // Count leading positional parameters. Name-value struct parameters
   // declared in an `arguments` block (entries like `opts.method`) are filled
@@ -713,9 +740,16 @@ export function callUserFunction(
     }
   }
   if (hasVarargin) {
-    const extraArgs = sharedArgs
-      .slice(regularParams.length)
-      .map(a => ensureRuntimeValue(a));
+    let extras = sharedArgs.slice(regularParams.length);
+    // When name-value struct params follow varargin, the repeating section
+    // ends at the first argument naming a declared option.
+    if (vararginIdx !== fn.params.length - 1) {
+      extras = extras.slice(
+        0,
+        nameValueTailStart(extras, nameValueFieldNames(fn))
+      );
+    }
+    const extraArgs = extras.map(a => ensureRuntimeValue(a));
     fnEnv.set("varargin", RTV.cell(extraArgs, [1, extraArgs.length]));
   }
   fnEnv.set("$nargin", narginOverride ?? args.length);
@@ -1288,6 +1322,41 @@ export function evalInLocalScope(
 
 // ── Arguments block processing ──────────────────────────────────────────
 
+/** Field names declared by dotted (name-value) entries across a function's
+ *  input arguments blocks. */
+function nameValueFieldNames(fn: FunctionDef): Set<string> {
+  const names = new Set<string>();
+  for (const block of fn.argumentsBlocks ?? []) {
+    if (block.kind === "Output" || block.kind === "OutputRepeating") continue;
+    for (const e of block.entries) {
+      const dot = e.name.indexOf(".");
+      if (dot >= 0) names.add(e.name.slice(dot + 1));
+    }
+  }
+  return names;
+}
+
+/** Index into `extras` where the trailing name-value section starts: the
+ *  first char/string argument matching a declared option field name.
+ *  Everything before it belongs to the repeating (varargin) section. */
+function nameValueTailStart(
+  extras: unknown[],
+  fieldNames: Set<string>
+): number {
+  if (fieldNames.size === 0) return extras.length;
+  for (let i = 0; i < extras.length; i++) {
+    if (extras[i] === undefined) continue;
+    const rv = ensureRuntimeValue(extras[i]);
+    if (
+      (isRuntimeChar(rv) || isRuntimeString(rv)) &&
+      fieldNames.has(toString(rv))
+    ) {
+      return i;
+    }
+  }
+  return extras.length;
+}
+
 /**
  * Apply `arguments`-block defaults and build name-value struct parameters,
  * binding the results into the *current* function environment.
@@ -1351,9 +1420,20 @@ export function processArgumentsBlocks(
 
     // Assemble each name-value struct parameter from the trailing arguments
     // (those past the struct parameter's position) plus field defaults.
+    const vararginIdx = fn.params.indexOf("varargin");
     for (const [paramName, fields] of nvGroups) {
       const pIdx = fn.params.indexOf(paramName);
-      const nvArgs = args.slice(pIdx >= 0 ? pIdx : args.length);
+      let nvArgs: unknown[];
+      if (pIdx >= 0 && vararginIdx >= 0 && vararginIdx < pIdx) {
+        // varargin consumes a variable number of arguments; the name-value
+        // tail starts at the first declared option name after it.
+        const extras = args.slice(vararginIdx);
+        nvArgs = extras.slice(
+          nameValueTailStart(extras, nameValueFieldNames(fn))
+        );
+      } else {
+        nvArgs = args.slice(pIdx >= 0 ? pIdx : args.length);
+      }
       const defaults: Record<string, unknown> = {};
       for (const { field, defaultExpr } of fields) {
         if (defaultExpr) defaults[field] = this.evalExpr(defaultExpr);

--- a/src/numbl-core/parser/ExpressionParser.ts
+++ b/src/numbl-core/parser/ExpressionParser.ts
@@ -320,9 +320,9 @@ export class ExpressionParser extends ParserBase {
           if (this.consume(Token.LParen)) {
             const args: Expr[] = [];
             if (!this.consume(Token.RParen)) {
-              args.push(this.parseExpr());
+              this.parseFuncArg(args);
               while (this.consume(Token.Comma)) {
-                args.push(this.parseExpr());
+                this.parseFuncArg(args);
               }
               if (!this.consume(Token.RParen)) {
                 throw this.error("expected ')' after method arguments");
@@ -357,9 +357,9 @@ export class ExpressionParser extends ParserBase {
         }
         const args: Expr[] = [];
         if (!this.consume(Token.RParen)) {
-          args.push(this.parseExpr());
+          this.parseFuncArg(args);
           while (this.consume(Token.Comma)) {
-            args.push(this.parseExpr());
+            this.parseFuncArg(args);
           }
           if (!this.consume(Token.RParen)) {
             throw this.error("expected ')' after super call arguments");

--- a/src/numbl-core/parser/FunctionParser.ts
+++ b/src/numbl-core/parser/FunctionParser.ts
@@ -67,13 +67,8 @@ export class FunctionParser extends ArgumentsParser {
 
     // Enforce varargs placement constraints
     const vararginIdx = params.indexOf("varargin");
-    if (vararginIdx !== -1) {
-      if (vararginIdx !== params.length - 1) {
-        throw this.error("'varargin' must be the last input parameter");
-      }
-      if (params.filter(p => p === "varargin").length > 1) {
-        throw this.error("'varargin' cannot appear more than once");
-      }
+    if (vararginIdx !== -1 && params.filter(p => p === "varargin").length > 1) {
+      throw this.error("'varargin' cannot appear more than once");
     }
     const varargoutIdx = outputs.indexOf("varargout");
     if (varargoutIdx !== -1) {
@@ -87,6 +82,26 @@ export class FunctionParser extends ArgumentsParser {
 
     // Optional arguments blocks (must appear before any executable statements)
     const argumentsBlocks = this.parseArgumentsBlocks();
+
+    // varargin must be the last input parameter, except that name-value
+    // struct parameters (declared via dotted `arguments` entries like
+    // `options.field`) may follow it, e.g. `function f(a, varargin, options)`.
+    if (vararginIdx !== -1 && vararginIdx !== params.length - 1) {
+      const nvBases = new Set<string>();
+      for (const block of argumentsBlocks) {
+        if (block.kind === "Output" || block.kind === "OutputRepeating")
+          continue;
+        for (const e of block.entries) {
+          const dot = e.name.indexOf(".");
+          if (dot >= 0) nvBases.add(e.name.slice(0, dot));
+        }
+      }
+      for (const p of params.slice(vararginIdx + 1)) {
+        if (!nvBases.has(p)) {
+          throw this.error("'varargin' must be the last input parameter");
+        }
+      }
+    }
 
     const body = this.parseBlock(t => t === Token.End);
     if (!this.consume(Token.End)) {

--- a/src/numbl-core/runtime/compare.ts
+++ b/src/numbl-core/runtime/compare.ts
@@ -64,6 +64,15 @@ export const valuesAreEqual = (a: RuntimeValue, b: RuntimeValue): boolean => {
     }
     case "dictionary":
       return a === b;
+    case "string_array": {
+      const sb = b as typeof a;
+      if (a.shape[0] !== sb.shape[0] || a.shape[1] !== sb.shape[1])
+        return false;
+      for (let i = 0; i < a.data.length; i++) {
+        if (a.data[i] !== sb.data[i]) return false;
+      }
+      return true;
+    }
     default:
       return false;
   }

--- a/src/numbl-core/runtime/constructors.ts
+++ b/src/numbl-core/runtime/constructors.ts
@@ -21,6 +21,7 @@ import {
   RuntimeStructArray,
   RuntimeSparseMatrix,
   RuntimeDictionary,
+  RuntimeStringArray,
   type RuntimeValue,
   isRuntimeNumber,
   isRuntimeLogical,
@@ -89,6 +90,11 @@ export const RTV = {
 
   string(value: string): RuntimeString {
     return value;
+  },
+
+  /** String array (does NOT collapse 1x1 — use stringArrayValue for that). */
+  stringArray(data: string[], shape: [number, number]): RuntimeStringArray {
+    return new RuntimeStringArray(data, shape);
   },
 
   char(value: string): RuntimeChar {

--- a/src/numbl-core/runtime/convert.ts
+++ b/src/numbl-core/runtime/convert.ts
@@ -93,6 +93,11 @@ export function toString(v: RuntimeValue): string {
   switch (v.kind) {
     case "char":
       return v.value;
+    case "string_array":
+      if (v.data.length === 1) return v.data[0];
+      throw new RuntimeError(
+        "Expected a scalar text value, got a string array"
+      );
     default:
       throw new RuntimeError(`Cannot convert ${kstr(v)} to string`);
   }

--- a/src/numbl-core/runtime/display.ts
+++ b/src/numbl-core/runtime/display.ts
@@ -15,6 +15,7 @@ import {
   isRuntimeNumber,
   isRuntimeString,
   RuntimeStructArray,
+  RuntimeStringArray,
 } from "./types.js";
 import { colMajorIndex, ind2sub } from "./utils.js";
 
@@ -66,7 +67,37 @@ export function displayValue(v: RuntimeValue): string {
       return formatDictionary(v);
     case "class_instance_array":
       return `  ${v.shape[0]}x${v.shape[1]} ${v.className} array`;
+    case "string_array":
+      return formatStringArray(v);
   }
+}
+
+/** Quoted, column-aligned grid like MATLAB's string-array display. */
+function formatStringArray(v: RuntimeStringArray): string {
+  const [rows, cols] = v.shape;
+  if (v.data.length === 0) {
+    return `  ${rows}x${cols} empty string array`;
+  }
+  // Column widths over the quoted representations
+  const quoted = v.data.map(s => `"${s}"`);
+  const widths: number[] = [];
+  for (let c = 0; c < cols; c++) {
+    let w = 0;
+    for (let r = 0; r < rows; r++) {
+      w = Math.max(w, quoted[c * rows + r].length);
+    }
+    widths.push(w);
+  }
+  const lines: string[] = [];
+  for (let r = 0; r < rows; r++) {
+    const parts: string[] = [];
+    for (let c = 0; c < cols; c++) {
+      const q = quoted[c * rows + r];
+      parts.push(c === cols - 1 ? q : q.padEnd(widths[c]));
+    }
+    lines.push("    " + parts.join("    "));
+  }
+  return lines.join("\n");
 }
 
 const formatStructArray = (v: RuntimeStructArray): string => {

--- a/src/numbl-core/runtime/indexing.ts
+++ b/src/numbl-core/runtime/indexing.ts
@@ -20,6 +20,9 @@ import {
   isRuntimeStruct,
   isRuntimeClassInstance,
   isRuntimeChar,
+  isRuntimeStringArray,
+  RuntimeStringArray,
+  stringArrayValue,
 } from "./types.js";
 import { RuntimeError } from "./error.js";
 import { RTV } from "./constructors.js";
@@ -1124,6 +1127,83 @@ function indexIntoChar(
   throw new RuntimeError("Char indexing supports 1 or 2 dimensions");
 }
 
+/** Resolve one subscript against a dimension of extent `extent` to 0-based
+ *  positions. Handles colon, scalars, numeric vectors, and logical masks. */
+export function stringArraySubscript(
+  idx: RuntimeValue,
+  extent: number
+): number[] {
+  if (isColonIndex(idx)) {
+    return Array.from({ length: extent }, (_, i) => i);
+  }
+  if (isRuntimeTensor(idx)) {
+    if (idx._isLogical) {
+      const out: number[] = [];
+      for (let i = 0; i < idx.data.length; i++)
+        if (idx.data[i] !== 0) out.push(i);
+      return out;
+    }
+    return Array.from(idx.data, (v: number) => Math.round(v) - 1);
+  }
+  if (isRuntimeLogical(idx)) return idx ? [0] : [];
+  return [Math.round(toNumber(idx)) - 1];
+}
+
+function indexIntoStringArray(
+  base: RuntimeStringArray,
+  indices: RuntimeValue[]
+): RuntimeValue {
+  const [rows, cols] = base.shape;
+  const total = base.data.length;
+
+  if (indices.length === 2) {
+    const ri = stringArraySubscript(indices[0], rows);
+    const ci = stringArraySubscript(indices[1], cols);
+    const out: string[] = [];
+    for (const c of ci) {
+      if (c < 0 || c >= cols)
+        throw new RuntimeError("Index exceeds array bounds");
+      for (const r of ri) {
+        if (r < 0 || r >= rows)
+          throw new RuntimeError("Index exceeds array bounds");
+        out.push(base.data[c * rows + r]);
+      }
+    }
+    return stringArrayValue(out, [ri.length, ci.length]);
+  }
+
+  if (indices.length !== 1) {
+    throw new RuntimeError("String array indexing supports 1 or 2 subscripts");
+  }
+
+  const idx = indices[0];
+  if (isColonIndex(idx)) {
+    return stringArrayValue(base.data.slice(), [total, 1]);
+  }
+  const linear = stringArraySubscript(idx, total);
+  const out: string[] = [];
+  for (const i of linear) {
+    if (i < 0 || i >= total)
+      throw new RuntimeError("Index exceeds array bounds");
+    out.push(base.data[i]);
+  }
+  // Orientation: vector sources keep their orientation; a matrix source
+  // takes the shape of a tensor index (MATLAB rule), else a row.
+  let shape: [number, number];
+  if (rows === 1 || cols === 1) {
+    shape = rows === 1 ? [1, out.length] : [out.length, 1];
+  } else if (isRuntimeTensor(idx) && !idx._isLogical) {
+    const is = idx.shape;
+    const im = is.length >= 2 ? is[0] : 1;
+    shape = [im, out.length / (im || 1)];
+  } else if (isRuntimeTensor(idx) && idx._isLogical) {
+    shape = [out.length, 1];
+  } else {
+    shape = [1, out.length];
+  }
+  return stringArrayValue(out, shape);
+}
+
 function indexIntoLogical(
   base: boolean,
   indices: RuntimeValue[]
@@ -1300,6 +1380,9 @@ export function indexIntoRTValue(
       if (i !== 1) throw new RuntimeError("Index exceeds string dimensions");
       return base;
     }
+  }
+  if (isRuntimeStringArray(base)) {
+    return indexIntoStringArray(base, indices);
   }
   if (isRuntimeLogical(base)) {
     return indexIntoLogical(base, indices);

--- a/src/numbl-core/runtime/runtime.ts
+++ b/src/numbl-core/runtime/runtime.ts
@@ -32,6 +32,7 @@ import {
   isRuntimeTensor,
   isRuntimeClassInstance,
   isRuntimeClassInstanceArray,
+  isRuntimeStringArray,
   isRuntimeCell,
   isRuntimeLogical,
   isRuntimeSparseMatrix,
@@ -1055,6 +1056,7 @@ export class Runtime {
         rv.shape ?? (rv.value.length === 0 ? [0, 0] : [1, rv.value.length])
       );
     if (isRuntimeString(rv)) return [1, 1];
+    if (isRuntimeStringArray(rv)) return [...rv.shape];
     if (isRuntimeClassInstance(rv)) return [1, 1];
     return [1, 1];
   }

--- a/src/numbl-core/runtime/runtimeDispatch.ts
+++ b/src/numbl-core/runtime/runtimeDispatch.ts
@@ -258,6 +258,9 @@ export function isa(
       case "class_instance_array":
         valueClass = mv.className;
         break;
+      case "string_array":
+        valueClass = "string";
+        break;
       default:
         valueClass = "unknown";
         break;
@@ -1072,6 +1075,8 @@ export function numblClass(v: RuntimeValue): string {
       return "double";
     case "class_instance":
       return v.className;
+    case "string_array":
+      return "string";
     default:
       return "unknown";
   }

--- a/src/numbl-core/runtime/runtimeIndexing.ts
+++ b/src/numbl-core/runtime/runtimeIndexing.ts
@@ -32,9 +32,13 @@ import {
   isRuntimeClassInstanceArray,
   isRuntimeSparseMatrix,
   isRuntimeDictionary,
+  isRuntimeStringArray,
+  stringArrayValue,
   type RuntimeClassInstanceArray,
   type RuntimeClassInstance,
 } from "../runtime/types.js";
+import { stringArraySubscript } from "./indexing.js";
+import { matlabNumToString } from "./utils.js";
 import {
   dictLookup,
   dictInsertSingle,
@@ -109,6 +113,10 @@ function endResolver(
     }
     if (isRuntimeStructArray(mv)) return mv.elements.length;
     if (isRuntimeClassInstanceArray(mv)) return mv.elements.length;
+    if (isRuntimeStringArray(mv)) {
+      if (numIndices === 1) return mv.data.length;
+      return dim < 2 ? mv.shape[dim] : 1;
+    }
     if (isRuntimeSparseMatrix(mv)) {
       if (numIndices === 1) return mv.m * mv.n;
       return dim === 0 ? mv.m : dim === 1 ? mv.n : 1;
@@ -498,6 +506,31 @@ export function indexCell(
     return val;
   }
 
+  // String brace indexing: str{i} extracts the element as a char vector
+  // (MATLAB: ["one" "two"]{2} -> 'two'; "abc"{1} -> 'abc').
+  if (isRuntimeString(mv) || isRuntimeStringArray(mv)) {
+    const idxMvals = resolveIndices(indices, endResolver(mv, indices.length));
+    const elems = isRuntimeString(mv) ? [mv] : mv.data;
+    const shape: [number, number] = isRuntimeString(mv) ? [1, 1] : mv.shape;
+    let lin: number;
+    if (idxMvals.length === 1) {
+      lin = Math.round(toNumber(idxMvals[0])) - 1;
+    } else if (idxMvals.length === 2) {
+      const r = Math.round(toNumber(idxMvals[0])) - 1;
+      const c = Math.round(toNumber(idxMvals[1])) - 1;
+      if (r < 0 || r >= shape[0] || c < 0 || c >= shape[1])
+        throw new RuntimeError("Index exceeds array bounds");
+      lin = c * shape[0] + r;
+    } else {
+      throw new RuntimeError(
+        "String brace indexing supports 1 or 2 subscripts"
+      );
+    }
+    if (lin < 0 || lin >= elems.length)
+      throw new RuntimeError("Index exceeds array bounds");
+    return RTV.char(elems[lin]);
+  }
+
   if (!isRuntimeCell(mv)) throw new RuntimeError("Cell indexing on non-cell");
   const idxMvals = resolveIndices(indices, endResolver(mv, indices.length));
   // CSL for 1D cell indexing
@@ -763,6 +796,18 @@ export function indexStore(
       return rhsMv;
     }
   }
+  // String / string-array indexed assignment (element replacement, growth,
+  // deletion). A primitive string base is a 1x1 string array; an empty
+  // tensor base with a string RHS starts a fresh string array.
+  {
+    const rhsMv0 = ensureRuntimeValue(rhs);
+    const baseIsStr = isRuntimeString(mv) || isRuntimeStringArray(mv);
+    const baseEmpty = isRuntimeTensor(mv) && mv.data.length === 0;
+    const rhsIsStr = isRuntimeString(rhsMv0) || isRuntimeStringArray(rhsMv0);
+    if (baseIsStr || (baseEmpty && rhsIsStr)) {
+      return stringArrayIndexStore(mv, indices, rhsMv0);
+    }
+  }
   // Convert scalar number/logical/complex to 1x1 tensor for indexed assignment
   let wasScalar = false;
   // A char base stays char: index-assign on its numeric code points, then
@@ -817,6 +862,131 @@ export function indexStore(
     return result.data[0];
   }
   return result;
+}
+
+/** Convert an assignment RHS to string elements, or null if unsupported. */
+function rhsToStringElems(rhsMv: RuntimeValue): string[] | null {
+  if (isRuntimeString(rhsMv)) return [rhsMv];
+  if (isRuntimeStringArray(rhsMv)) return rhsMv.data.slice();
+  if (isRuntimeChar(rhsMv)) {
+    const rows = rhsMv.shape ? rhsMv.shape[0] : 1;
+    if (rows <= 1) return [rhsMv.value];
+    const width = rhsMv.shape![1];
+    const out: string[] = [];
+    for (let r = 0; r < rows; r++)
+      out.push(rhsMv.value.slice(r * width, (r + 1) * width));
+    return out;
+  }
+  if (isRuntimeNumber(rhsMv)) return [matlabNumToString(rhsMv)];
+  if (isRuntimeLogical(rhsMv)) return [rhsMv ? "true" : "false"];
+  if (isRuntimeTensor(rhsMv))
+    return Array.from(rhsMv.data, d => matlabNumToString(d));
+  return null;
+}
+
+/** Indexed assignment where the destination is a string array (or a scalar
+ *  string / empty tensor becoming one). Supports growth (gaps fill with ""
+ *  — numbl has no <missing>) and deletion via s(idx) = []. */
+function stringArrayIndexStore(
+  mv: RuntimeValue,
+  indices: unknown[],
+  rhsMv: RuntimeValue
+): RuntimeValue {
+  let data: string[];
+  let rows: number;
+  let cols: number;
+  if (isRuntimeStringArray(mv)) {
+    data = mv.data.slice();
+    [rows, cols] = mv.shape;
+  } else if (isRuntimeString(mv)) {
+    data = [mv];
+    rows = 1;
+    cols = 1;
+  } else {
+    data = [];
+    rows = 0;
+    cols = 0;
+  }
+
+  const idxMvals = resolveIndices(indices, endResolver(mv, indices.length));
+
+  // Deletion: s(idx) = []
+  if (
+    isRuntimeTensor(rhsMv) &&
+    rhsMv.data.length === 0 &&
+    idxMvals.length === 1
+  ) {
+    const del = new Set(stringArraySubscript(idxMvals[0], data.length));
+    const kept = data.filter((_, i) => !del.has(i));
+    if (cols === 1 && rows > 1) return stringArrayValue(kept, [kept.length, 1]);
+    return stringArrayValue(kept, [1, kept.length]);
+  }
+
+  const rhsElems = rhsToStringElems(rhsMv);
+  if (rhsElems === null) {
+    throw new RuntimeError("Cannot assign this value into a string array");
+  }
+
+  if (idxMvals.length === 1) {
+    const positions = stringArraySubscript(idxMvals[0], data.length);
+    const maxPos = positions.length ? Math.max(...positions) : -1;
+    if (positions.some(p => p < 0)) {
+      throw new RuntimeError("Index must be a positive integer");
+    }
+    if (maxPos >= data.length) {
+      if (rows > 1 && cols > 1) {
+        throw new RuntimeError("Index exceeds array bounds");
+      }
+      while (data.length <= maxPos) data.push("");
+    }
+    if (rhsElems.length !== 1 && rhsElems.length !== positions.length) {
+      throw new RuntimeError(
+        "Unable to perform assignment because the left and right sides have a different number of elements"
+      );
+    }
+    positions.forEach((p, k) => {
+      data[p] = rhsElems.length === 1 ? rhsElems[0] : rhsElems[k];
+    });
+    if (rows > 1 && cols > 1) return stringArrayValue(data, [rows, cols]);
+    if (cols === 1 && rows > 1) return stringArrayValue(data, [data.length, 1]);
+    return stringArrayValue(data, [1, data.length]);
+  }
+
+  if (idxMvals.length === 2) {
+    const ri = stringArraySubscript(idxMvals[0], rows);
+    const ci = stringArraySubscript(idxMvals[1], cols);
+    if (ri.some(p => p < 0) || ci.some(p => p < 0)) {
+      throw new RuntimeError("Index must be a positive integer");
+    }
+    const newRows = Math.max(rows, ri.length ? Math.max(...ri) + 1 : 0);
+    const newCols = Math.max(cols, ci.length ? Math.max(...ci) + 1 : 0);
+    let grid = data;
+    if (newRows !== rows || newCols !== cols) {
+      grid = new Array<string>(newRows * newCols).fill("");
+      for (let c = 0; c < cols; c++) {
+        for (let r = 0; r < rows; r++) {
+          grid[c * newRows + r] = data[c * rows + r];
+        }
+      }
+    }
+    const count = ri.length * ci.length;
+    if (rhsElems.length !== 1 && rhsElems.length !== count) {
+      throw new RuntimeError(
+        "Unable to perform assignment because the left and right sides have a different number of elements"
+      );
+    }
+    let k = 0;
+    for (const c of ci) {
+      for (const r of ri) {
+        grid[c * newRows + r] =
+          rhsElems.length === 1 ? rhsElems[0] : rhsElems[k];
+        k++;
+      }
+    }
+    return stringArrayValue(grid, [newRows, newCols]);
+  }
+
+  throw new RuntimeError("String array assignment supports 1 or 2 subscripts");
 }
 
 /**

--- a/src/numbl-core/runtime/runtimeOperators.ts
+++ b/src/numbl-core/runtime/runtimeOperators.ts
@@ -45,6 +45,8 @@ import {
   isRuntimeCell,
   isRuntimeChar,
   isRuntimeSparseMatrix,
+  isRuntimeStringArray,
+  stringArrayValue,
 } from "../runtime/types.js";
 import { END_SENTINEL } from "./sentinels.js";
 
@@ -393,6 +395,17 @@ export function forIter(v: unknown): unknown[] {
   }
   if (isRuntimeChar(mv)) {
     return Array.from(mv.value).map(c => RTV.char(c));
+  }
+  if (isRuntimeStringArray(mv)) {
+    // Iterate columns, like tensors: each iteration value is one column.
+    const [rows, cols] = mv.shape;
+    const out: RuntimeValue[] = [];
+    for (let c = 0; c < cols; c++) {
+      out.push(
+        stringArrayValue(mv.data.slice(c * rows, (c + 1) * rows), [rows, 1])
+      );
+    }
+    return out;
   }
   return [v];
 }

--- a/src/numbl-core/runtime/specialBuiltinNames.ts
+++ b/src/numbl-core/runtime/specialBuiltinNames.ts
@@ -15,6 +15,7 @@ export const SPECIAL_BUILTIN_NAMES: readonly string[] = [
   "fclose",
   "fgetl",
   "fgets",
+  "fscanf",
   "fileread",
   "feof",
   "ferror",

--- a/src/numbl-core/runtime/specialBuiltins.ts
+++ b/src/numbl-core/runtime/specialBuiltins.ts
@@ -24,12 +24,14 @@ import {
   isRuntimeDictionary,
   isRuntimeStruct,
   isRuntimeSparseMatrix,
+  isRuntimeStringArray,
   type RuntimeTensor,
 } from "../runtime/types.js";
 import { applyHandleProperty } from "./struct-access.js";
 import { incref, decref } from "./refcount.js";
 import type { PlotInstruction } from "../../graphics/types.js";
 import { sprintfFormat } from "../../numbl-core/helpers/string.js";
+import { scanFormat } from "../helpers/scanFormat.js";
 import { ensureRuntimeValue } from "./runtimeHelpers.js";
 import {
   arrayfunImpl as _arrayfunImpl,
@@ -267,8 +269,14 @@ export function registerSpecialBuiltins(rt: Runtime): void {
 
       const fmt = toString(margs[fmtIdx]);
       // sprintfFormat handles tensor flattening and format cycling internally,
-      // so we can pass the remaining args through directly.
-      output = sprintfFormat(fmt, margs.slice(fmtIdx + 1));
+      // so we can pass the remaining args through directly. String arrays
+      // supply one text arg per element.
+      const rest = margs
+        .slice(fmtIdx + 1)
+        .flatMap(a =>
+          isRuntimeStringArray(a) ? a.data.map(s => RTV.string(s)) : [a]
+        );
+      output = sprintfFormat(fmt, rest);
 
       if (fid === 1 || fid === 2) {
         rt.output(output);
@@ -457,6 +465,62 @@ export function registerSpecialBuiltins(rt: Runtime): void {
     if (margs.length < 1) throw new RuntimeError("fgets requires 1 argument");
     const result = io.fgets(toNumber(margs[0]));
     return typeof result === "number" ? RTV.num(result) : RTV.char(result);
+  });
+
+  registerSpecial("fscanf", (nargout, args) => {
+    const io = requireFileIO();
+    const margs = args.map(a => ensureRuntimeValue(a));
+    if (margs.length < 2)
+      throw new RuntimeError("fscanf requires at least 2 arguments");
+    if (!io.ftell || !io.fseek || !io.freadBytes)
+      throw new RuntimeError("fscanf is not supported in this environment");
+    const fid = toNumber(margs[0]);
+    const fmt = toString(margs[1]);
+
+    // Optional sizeA: scalar count (possibly Inf) or [m, n] (n possibly Inf).
+    let maxCount = Infinity;
+    let rows: number | null = null;
+    if (margs.length >= 3) {
+      const sz = margs[2];
+      if (isRuntimeTensor(sz) && sz.data.length >= 2) {
+        rows = sz.data[0];
+        maxCount = sz.data[0] * sz.data[1];
+      } else {
+        maxCount = toNumber(sz);
+      }
+    }
+
+    // Read the remainder of the file (latin-1, one char per byte), scan it,
+    // then reposition after the last consumed character.
+    const pos = io.ftell(fid);
+    const CHUNK = 1 << 16;
+    const chunks: string[] = [];
+    for (;;) {
+      const bytes = io.freadBytes(fid, CHUNK);
+      let s = "";
+      for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+      chunks.push(s);
+      if (bytes.length < CHUNK) break;
+    }
+    const { results, consumed } = scanFormat(chunks.join(""), fmt, maxCount);
+    io.fseek(fid, pos + consumed, -1);
+
+    const n = results.length;
+    let out: RuntimeValue;
+    if (rows !== null && Number.isFinite(rows) && rows > 0) {
+      // Column-major fill with `rows` rows; a partial final column is
+      // zero-padded.
+      const cols = Math.ceil(n / rows);
+      const data = allocFloat64Array(rows * cols);
+      for (let i = 0; i < n; i++) data[i] = results[i];
+      out = RTV.tensor(data, [rows, cols]);
+    } else if (n === 1) {
+      out = RTV.num(results[0]);
+    } else {
+      out = RTV.tensor(allocFloat64Array(results), [n, 1]);
+    }
+    if (nargout >= 2) return [out, RTV.num(n)];
+    return out;
   });
 
   registerSpecial("fileread", (_nargout, args) => {

--- a/src/numbl-core/runtime/tensor-construction.ts
+++ b/src/numbl-core/runtime/tensor-construction.ts
@@ -17,13 +17,15 @@ import {
   isRuntimeSparseMatrix,
   isRuntimeStruct,
   isRuntimeStructArray,
+  isRuntimeStringArray,
+  stringArrayValue,
   type RuntimeSparseMatrix,
   RuntimeChar,
   kstr,
 } from "./types.js";
 import { RuntimeError } from "./error.js";
 import { RTV } from "./constructors.js";
-import { numel } from "./utils.js";
+import { numel, matlabNumToString } from "./utils.js";
 import { allocFloat64Array } from "./alloc.js";
 
 /** Create a range start:end or start:step:end */
@@ -77,28 +79,21 @@ export function horzcat(...values: RuntimeValue[]): RuntimeValue {
     return cellCatAlongDim(values, 1);
   }
 
+  // If any element is a string, the result is a string ARRAY (MATLAB rule:
+  // string wins over char; each char operand becomes one string element).
+  if (values.some(v => isRuntimeString(v) || isRuntimeStringArray(v))) {
+    return stringCat(values, 1);
+  }
+
   // If any element is a char, concatenate as char array
   if (values.some(v => isRuntimeChar(v))) {
     let result = "";
     for (const v of values) {
       if (isRuntimeChar(v)) result += v.value;
-      else if (isRuntimeString(v)) result += v;
       else if (isRuntimeNumber(v)) result += String.fromCharCode(Math.round(v));
       else throw new RuntimeError(`Cannot concatenate ${kstr(v)} into char`);
     }
     return RTV.char(result);
-  }
-
-  // If any element is a string or char, concatenate as strings
-  if (values.some(v => isRuntimeString(v) || isRuntimeChar(v))) {
-    let result = "";
-    for (const v of values) {
-      if (isRuntimeString(v)) result += v;
-      else if (isRuntimeChar(v)) result += v.value;
-      else if (isRuntimeNumber(v)) result += String(v);
-      else throw new RuntimeError(`Cannot concatenate ${v} into string`);
-    }
-    return RTV.string(result);
   }
 
   // Struct / struct-array concatenation: [sA, sB]
@@ -125,6 +120,11 @@ export function vertcat(...values: RuntimeValue[]): RuntimeValue {
     return cellCatAlongDim(values, 0);
   }
 
+  // String operands make the result a string array (see horzcat).
+  if (values.some(v => isRuntimeString(v) || isRuntimeStringArray(v))) {
+    return stringCat(values, 0);
+  }
+
   // If any element is a char, build a 2-D char array (rows stacked).
   if (values.some(v => isRuntimeChar(v))) {
     return vertcatChars(values);
@@ -136,6 +136,107 @@ export function vertcat(...values: RuntimeValue[]): RuntimeValue {
   }
 
   return catAlongDim(values, 0); // dim 1 = 0-based index 0
+}
+
+// ── String-array concatenation ──────────────────────────────────────────
+
+interface StrBlock {
+  /** Elements in column-major order. */
+  data: string[];
+  rows: number;
+  cols: number;
+}
+
+/** Convert a concat operand to a string block, or null for empties (which
+ *  MATLAB drops from concatenations). */
+function toStringBlock(v: RuntimeValue): StrBlock | null {
+  if (isRuntimeString(v)) return { data: [v], rows: 1, cols: 1 };
+  if (isRuntimeStringArray(v)) {
+    if (v.data.length === 0) return null;
+    return { data: v.data.slice(), rows: v.shape[0], cols: v.shape[1] };
+  }
+  if (isRuntimeChar(v)) {
+    const rows = v.shape ? v.shape[0] : 1;
+    const width = v.shape ? v.shape[1] : v.value.length;
+    if (rows <= 1) return { data: [v.value], rows: 1, cols: 1 };
+    // A multi-row char matrix contributes one string element per row.
+    const out: string[] = [];
+    for (let r = 0; r < rows; r++) {
+      out.push(v.value.slice(r * width, (r + 1) * width));
+    }
+    return { data: out, rows, cols: 1 };
+  }
+  if (isRuntimeNumber(v)) {
+    return { data: [matlabNumToString(v)], rows: 1, cols: 1 };
+  }
+  if (isRuntimeLogical(v)) {
+    return { data: [v ? "true" : "false"], rows: 1, cols: 1 };
+  }
+  if (isRuntimeTensor(v)) {
+    if (v.data.length === 0) return null;
+    const rows = v.shape.length >= 2 ? v.shape[0] : 1;
+    const cols = v.data.length / (rows || 1);
+    const out: string[] = [];
+    for (let i = 0; i < v.data.length; i++) {
+      out.push(
+        v._isLogical
+          ? v.data[i]
+            ? "true"
+            : "false"
+          : matlabNumToString(v.data[i])
+      );
+    }
+    return { data: out, rows, cols };
+  }
+  throw new RuntimeError(`Cannot concatenate ${kstr(v)} into string array`);
+}
+
+/** Concatenate operands into a string array along dim (0 = rows, 1 = cols).
+ *  1x1 results collapse to a primitive string. */
+function stringCat(values: RuntimeValue[], dim: 0 | 1): RuntimeValue {
+  const blocks: StrBlock[] = [];
+  for (const v of values) {
+    const b = toStringBlock(v);
+    if (b) blocks.push(b);
+  }
+  if (blocks.length === 0) return RTV.stringArray([], [0, 0]);
+  if (dim === 1) {
+    const rows = blocks[0].rows;
+    let cols = 0;
+    for (const b of blocks) {
+      if (b.rows !== rows) {
+        throw new RuntimeError(
+          "Dimensions of arrays being concatenated are not consistent"
+        );
+      }
+      cols += b.cols;
+    }
+    // Column-major blocks placed side by side are just concatenated data.
+    const data: string[] = [];
+    for (const b of blocks) data.push(...b.data);
+    return stringArrayValue(data, [rows, cols]);
+  }
+  const cols = blocks[0].cols;
+  let rows = 0;
+  for (const b of blocks) {
+    if (b.cols !== cols) {
+      throw new RuntimeError(
+        "Dimensions of arrays being concatenated are not consistent"
+      );
+    }
+    rows += b.rows;
+  }
+  const data: string[] = new Array(rows * cols);
+  let rOff = 0;
+  for (const b of blocks) {
+    for (let c = 0; c < cols; c++) {
+      for (let r = 0; r < b.rows; r++) {
+        data[c * rows + rOff + r] = b.data[c * b.rows + r];
+      }
+    }
+    rOff += b.rows;
+  }
+  return stringArrayValue(data, [rows, cols]);
 }
 
 /** Vertical concatenation when at least one operand is a char array.

--- a/src/numbl-core/runtime/types.ts
+++ b/src/numbl-core/runtime/types.ts
@@ -26,7 +26,8 @@ export type RuntimeValue =
   | RuntimeStructArray
   | RuntimeClassInstanceArray
   | RuntimeSparseMatrix
-  | RuntimeDictionary;
+  | RuntimeDictionary
+  | RuntimeStringArray;
 
 export type RuntimeNumber = number;
 export type RuntimeLogical = boolean;
@@ -109,6 +110,12 @@ export const isRuntimeDictionary = (
   typeof value === "object" &&
   value !== null &&
   (value as RuntimeDictionary).kind === "dictionary";
+export const isRuntimeStringArray = (
+  value: RuntimeValue
+): value is RuntimeStringArray =>
+  typeof value === "object" &&
+  value !== null &&
+  (value as RuntimeStringArray).kind === "string_array";
 
 export const kstr = (value: RuntimeValue): string => {
   if (isRuntimeNumber(value)) return "number";
@@ -128,6 +135,7 @@ export const kstr = (value: RuntimeValue): string => {
   if (isRuntimeStructArray(value)) return "struct array";
   if (isRuntimeSparseMatrix(value)) return "sparse matrix";
   if (isRuntimeDictionary(value)) return "dictionary";
+  if (isRuntimeStringArray(value)) return "string array";
   return "unknown";
 };
 
@@ -175,6 +183,32 @@ export class RuntimeChar extends Refcounted {
     this.value = value;
     this.shape = shape;
   }
+}
+
+export class RuntimeStringArray extends Refcounted {
+  readonly kind = "string_array" as const;
+  /** Elements in column-major order (plain JS strings). */
+  data: string[];
+  /** 2-D shape [rows, cols]; data.length === rows*cols. A 1x1 string is
+   *  normally represented as a primitive JS string, not a 1x1 array —
+   *  use stringArrayValue() to build results so scalars collapse. */
+  shape: [number, number];
+
+  constructor(data: string[], shape: [number, number]) {
+    super();
+    this.data = data;
+    this.shape = shape;
+  }
+}
+
+/** Build a string-array result, collapsing 1x1 to the primitive string
+ *  representation used for string scalars throughout the runtime. */
+export function stringArrayValue(
+  data: string[],
+  shape: [number, number]
+): RuntimeValue {
+  if (data.length === 1 && shape[0] === 1 && shape[1] === 1) return data[0];
+  return new RuntimeStringArray(data, shape);
 }
 
 export class RuntimeCell extends Refcounted {

--- a/src/numbl-core/runtime/utils.ts
+++ b/src/numbl-core/runtime/utils.ts
@@ -55,3 +55,29 @@ export function sub2ind(shape: number[], subs: number[]): number {
   }
   return idx;
 }
+
+/** MATLAB num2str/string(double) default formatting: integers exact,
+ *  otherwise 5 significant digits (%.5g with MATLAB exponent padding). */
+export function matlabNumToString(n: number): string {
+  if (n === Infinity) return "Inf";
+  if (n === -Infinity) return "-Inf";
+  if (isNaN(n)) return "NaN";
+  if (n === 0) return "0";
+  if (Number.isInteger(n)) return String(n);
+  const prec = 5;
+  const exp = Math.floor(Math.log10(Math.abs(n)));
+  let s: string;
+  if (exp < -4 || exp >= prec) {
+    s = n.toExponential(prec - 1);
+    const ePos = s.indexOf("e");
+    let mantissa = s.slice(0, ePos);
+    const expPart0 = s.slice(ePos);
+    if (mantissa.includes(".")) mantissa = mantissa.replace(/\.?0+$/, "");
+    const expPart = expPart0.replace(/([eE][+-])(\d)$/, "$1" + "0$2");
+    s = mantissa + expPart;
+  } else {
+    s = n.toPrecision(prec);
+    if (s.includes(".")) s = s.replace(/\.?0+$/, "");
+  }
+  return s;
+}

--- a/src/vfs/BrowserFileIOAdapter.ts
+++ b/src/vfs/BrowserFileIOAdapter.ts
@@ -454,20 +454,26 @@ export class BrowserFileIOAdapter implements FileIOAdapter {
     entry.dirty = true;
   }
 
+  /**
+   * `entry.pos` stays the logical (consumed) byte position: the text buffer
+   * holds the bytes starting at `entry.pos`, and consuming a line advances
+   * `entry.pos` by its byte length. This keeps fgetl/fgets coherent with
+   * freadBytes/fseek/ftell (and fscanf, which mixes the two).
+   */
   private readLine(entry: VFSOpenFile, keepNewline: boolean): string | number {
     // Fill text buffer from binary data
     while (!entry.eof) {
       const nlIdx = entry.buffer.indexOf("\n");
       if (nlIdx !== -1) break;
 
-      const available = entry.dataLen - entry.pos;
+      const bufStart = entry.pos + TEXT_ENCODER.encode(entry.buffer).length;
+      const available = entry.dataLen - bufStart;
       if (available <= 0) {
         entry.eof = true;
         break;
       }
       const toRead = Math.min(READ_CHUNK_SIZE, available);
-      const chunk = entry.data.subarray(entry.pos, entry.pos + toRead);
-      entry.pos += toRead;
+      const chunk = entry.data.subarray(bufStart, bufStart + toRead);
       entry.buffer += TEXT_DECODER.decode(chunk, { stream: true });
     }
 
@@ -477,16 +483,17 @@ export class BrowserFileIOAdapter implements FileIOAdapter {
 
     const nlIdx = entry.buffer.indexOf("\n");
     if (nlIdx !== -1) {
-      const line = keepNewline
-        ? entry.buffer.slice(0, nlIdx + 1)
-        : entry.buffer.slice(0, nlIdx);
+      const consumed = entry.buffer.slice(0, nlIdx + 1);
+      const line = keepNewline ? consumed : entry.buffer.slice(0, nlIdx);
       entry.buffer = entry.buffer.slice(nlIdx + 1);
+      entry.pos += TEXT_ENCODER.encode(consumed).length;
       return line;
     }
 
     // No newline found but we have data (EOF mid-line)
     const line = entry.buffer;
     entry.buffer = "";
+    entry.pos += TEXT_ENCODER.encode(line).length;
     return line;
   }
 


### PR DESCRIPTION
## String arrays

New `RuntimeStringArray` runtime kind: column-major `data: string[]` + 2-D shape. A 1×1 string always collapses to the existing string primitive (`stringArrayValue`), so string scalars behave exactly as before. The JIT sees string arrays as `unknown` and declines safely.

- Concatenation: `["a" 'b' 1.5]` → string array (string wins over char; numbers convert num2str-style). `string([])` is a true 0×0 empty that vanishes in concatenation.
- Indexing: paren reads (linear/2-D/colon/logical/`end`), brace extraction (`str{i}` → char), assignment with growth (`strings(0); s(end+1)=...`), scalar expansion, and deletion (`s(i)=[]`).
- Operators: elementwise `==` `~=` `<` `>`, `+` append (`"abc"+1` → `"abc1"`), transpose, reshape, for-loop column iteration, MATLAB-style display grid.
- New builtins: `strings`, `split`, `join`, `cellstr`, `newline`, `ismissing`. Upgraded: `string`, `char`, `double`, `str2double`, `strlength`, `strjoin`, `strsplit` (char input now yields a cellstr of chars, matching MATLAB), `unique`, `sort`, `ismember`, `contains`/`startsWith`/`endsWith`, `strcmp(i)`, `lower`/`upper`/`strtrim`/`deblank`/`reverse`, `erase`, `replace`, `sprintf`/`fprintf`.
- Known divergence: numbl has no `<missing>` value — growth gaps fill with `""` and `string(NaN)` is `"NaN"`.

## Fixes found while getting `mip-org/labs/meshio` working

- Name=Value argument desugaring now applies to method/super call argument lists (`pkg.fn(x=1)`, `obj.m(x=1)`) — previously only plain calls.
- `function f(a, varargin, opts)`: name-value struct params may follow `varargin`; trailing name-value args split from the repeating section by declared option names.
- `regexp(..., 'split')` output mode.
- New `fscanf` builtin (shares a `scanFormat` core with `sscanf`).
- Node and browser fileIO adapters now keep one logical file position, so `fgetl`/`fscanf`/`ftell`/`fseek` compose correctly.
- Implicit static `ClassName.empty(m,n)` (both call forms), default `end` on scalar objects without an `end` overload, and `reshape` on object arrays.

## Testing

- All new behavior probed against `matlab -batch` before implementing; the 10 new scripts in `numbl_test_scripts/` pass in **both numbl and MATLAB**.
- Suites green: 1744 unit tests, 860 integration scripts, jit-parity 81/81.
- `meshio.read` on a gmsh v2.2 file works end-to-end, including the `Mesh` display path (`strings(0)` growth + `strjoin`).