### PR TITLE
Route .mtoc2.js user functions through builtin multi-assign

### DIFF
--- a/src/numbl-core/jit/lowering/lowerMultiAssign.ts
+++ b/src/numbl-core/jit/lowering/lowerMultiAssign.ts
@@ -194,6 +194,32 @@ export function lowerMultiAssign(
     }
   }
 
+  // `.mtoc2.js` user functions opt in the same way: their loaded
+  // `Builtin` carries the identical `transfer(argTypes, nargout)`
+  // contract (lowerFuncCall already treats them interchangeably for
+  // single-output calls), and codegen resolves their `emit` through
+  // the workspace lookup. Route through the shared builder so
+  // `[a, b] = f(x, y)` works for workspace-defined builtins too.
+  if (target?.kind === "mtoc2UserFunction") {
+    const userBuiltin = this.workspace.getUserBuiltin(target.name);
+    if (!userBuiltin) {
+      throw new UnsupportedConstruct(
+        `internal: workspace resolved '${callName}' to a .mtoc2.js ` +
+          `function but no Builtin is loaded`,
+        s.span
+      );
+    }
+    return buildBuiltinMultiAssign.call(
+      this,
+      callName,
+      userBuiltin,
+      anfArgs,
+      argTypes,
+      argHoists,
+      s
+    );
+  }
+
   if (target?.kind !== "userFunction") {
     throw new UnsupportedConstruct(
       `multi-assign of '${callName}': only user-defined functions can ` +


### PR DESCRIPTION
`[a, b] = f(x, y)` previously worked only for registry builtins and user-defined MATLAB functions; a workspace `.mtoc2.js` function fell through to *"only user-defined functions can appear on the right of `[...] = ...`"*.

The asymmetry: `lowerFuncCall` already treats mtoc2 functions exactly like registry builtins for single-output calls — same loaded `Builtin` object, same `transfer(argTypes, nargout)` contract. This adds the symmetric branch in `lowerMultiAssign`: resolve the `Builtin` via `workspace.getUserBuiltin(name)` and reuse the existing `buildBuiltinMultiAssign` builder, which validates arity/types via the function's own `transfer` hook and emits the same `MultiAssignCall` IR shape.

Motivation: lets a workspace-defined builtin type multi-output calls — turing-surface uses this for explicitly grouped (batched) spherical-harmonic transforms, `[a, b] = synth(x, y)`, where output k is the transform of input k. turing-surface's CI pins numbl by commit and will bump its `NUMBL_REF` to whatever hash this lands as.